### PR TITLE
policyeval/execute: add a fallback to history iteration when redacting users

### DIFF
--- a/policyeval/commands.go
+++ b/policyeval/commands.go
@@ -192,7 +192,7 @@ func (pe *PolicyEvaluator) HandleCommand(ctx context.Context, evt *event.Event) 
 			return
 		}
 		reason := strings.Join(args[2:], " ")
-		redactedCount, err := pe.redactRecentMessages(ctx, room, since, reason)
+		redactedCount, err := pe.redactRecentMessages(ctx, room, "", since, reason)
 		if err != nil {
 			pe.sendNotice(ctx, "Failed to redact recent messages: %v", err)
 			return


### PR DESCRIPTION
In the event that both the synapse database and MSC4194 are unavailable, this change will allow `!redact` and `spam` bans to iterate over the past 24 hours of history in each protected room in order to redact a sender's messages.