### PR TITLE
policyeval/execute: allow configuring ban reasons that trigger redactions

### DIFF
--- a/cmd/meowlnir/main.go
+++ b/cmd/meowlnir/main.go
@@ -11,8 +11,6 @@ import (
 	"sync"
 	"syscall"
 
-	"go.mau.fi/util/glob"
-
 	_ "github.com/lib/pq"
 	"github.com/rs/zerolog"
 	up "go.mau.fi/util/configupgrade"
@@ -21,6 +19,7 @@ import (
 	"go.mau.fi/util/exerrors"
 	"go.mau.fi/util/exslices"
 	"go.mau.fi/util/exzerolog"
+	"go.mau.fi/util/glob"
 	"go.mau.fi/util/ptr"
 	"gopkg.in/yaml.v3"
 	flag "maunium.net/go/mauflag"
@@ -166,13 +165,9 @@ func (m *Meowlnir) Init(configPath string, noSaveConfig bool) {
 	m.EvaluatorByManagementRoom = make(map[id.RoomID]*policyeval.PolicyEvaluator)
 
 	var compiledGlobs []glob.Glob
-	if len(m.Config.Meowlnir.HackyRedactPatterns) == 0 {
-		compiledGlobs = nil
-	} else {
-		for _, pattern := range m.Config.Meowlnir.HackyRedactPatterns {
-			compiled := glob.Compile(pattern)
-			compiledGlobs = append(compiledGlobs, compiled)
-		}
+	for _, pattern := range m.Config.Meowlnir.HackyRedactPatterns {
+		compiled := glob.Compile(pattern)
+		compiledGlobs = append(compiledGlobs, compiled)
 	}
 	m.HackyAutoRedactPatterns = compiledGlobs
 

--- a/config/config.go
+++ b/config/config.go
@@ -28,8 +28,9 @@ type MeowlnirConfig struct {
 	ManagementSecret string `yaml:"management_secret"`
 	DryRun           bool   `yaml:"dry_run"`
 
-	ReportRoom      id.RoomID `yaml:"report_room"`
-	HackyRuleFilter []string  `yaml:"hacky_rule_filter"`
+	ReportRoom          id.RoomID `yaml:"report_room"`
+	HackyRuleFilter     []string  `yaml:"hacky_rule_filter"`
+	HackyRedactPatterns []string  `yaml:"hacky_redact_patterns"`
 }
 
 type AntispamConfig struct {

--- a/config/example-config.yaml
+++ b/config/example-config.yaml
@@ -36,6 +36,12 @@ meowlnir:
     hacky_rule_filter:
     - "@user:example.com"
     - example.com
+    # If a policy reason matches any of these patterns, the bot will automatically redact all messages from the banned
+    # target. The reason `spam` is already implicit. Ignored for takedowns.
+    # Uses a glob pattern to match.
+    hacky_redact_patterns:
+    - "example?"
+    - "redact:*"
 
 antispam:
     # Secret used for the synapse-http-antispam API. Same rules apply as for management_secret under meowlnir.

--- a/config/example-config.yaml
+++ b/config/example-config.yaml
@@ -40,8 +40,7 @@ meowlnir:
     # target. The reason `spam` is already implicit. Ignored for takedowns.
     # Uses a glob pattern to match.
     hacky_redact_patterns:
-    - "example?"
-    - "redact:*"
+    - "spam"
 
 antispam:
     # Secret used for the synapse-http-antispam API. Same rules apply as for management_secret under meowlnir.

--- a/config/upgrade.go
+++ b/config/upgrade.go
@@ -34,7 +34,7 @@ func upgradeConfig(helper up.Helper) {
 	helper.Copy(up.Bool, "meowlnir", "dry_run")
 	helper.Copy(up.Str|up.Null, "meowlnir", "report_room")
 	helper.Copy(up.List, "meowlnir", "hacky_rule_filter")
-	helper.Copy(up.Bool, "meowlnir", "filter_local_invites")
+	helper.Copy(up.Bool, "meowlnir", "hacky_redact_patterns")
 
 	if secret, ok := helper.Get(up.Str, "meowlnir", "antispam_secret"); ok && secret != "generate" {
 		helper.Set(up.Str, secret, "antispam", "secret")

--- a/config/upgrade.go
+++ b/config/upgrade.go
@@ -42,6 +42,7 @@ func upgradeConfig(helper up.Helper) {
 		generateOrCopy(helper, "antispam", "secret")
 	}
 	helper.Copy(up.Str|up.Null, "antispam", "auto_reject_invites_token")
+	helper.Copy(up.Bool, "antispam", "filter_local_invites")
 
 	if secret, ok := helper.Get(up.Str, "meowlnir", "pickle_key"); ok && secret != "generate" {
 		helper.Set(up.Str, secret, "encryption", "pickle_key")

--- a/config/upgrade.go
+++ b/config/upgrade.go
@@ -34,7 +34,7 @@ func upgradeConfig(helper up.Helper) {
 	helper.Copy(up.Bool, "meowlnir", "dry_run")
 	helper.Copy(up.Str|up.Null, "meowlnir", "report_room")
 	helper.Copy(up.List, "meowlnir", "hacky_rule_filter")
-	helper.Copy(up.Bool, "meowlnir", "hacky_redact_patterns")
+	helper.Copy(up.List, "meowlnir", "hacky_redact_patterns")
 
 	if secret, ok := helper.Get(up.Str, "meowlnir", "antispam_secret"); ok && secret != "generate" {
 		helper.Set(up.Str, secret, "antispam", "secret")

--- a/policyeval/execute.go
+++ b/policyeval/execute.go
@@ -46,8 +46,8 @@ func (pe *PolicyEvaluator) ApplyPolicy(ctx context.Context, userID id.UserID, po
 			for _, room := range rooms {
 				pe.ApplyBan(ctx, userID, room, recs.BanOrUnban)
 			}
-			shouldRedact := recs.BanOrUnban.Reason == "spam" || recs.BanOrUnban.Recommendation == event.PolicyRecommendationUnstableTakedown
-			if !shouldRedact && len(pe.autoRedactPatterns) > 0 && recs.BanOrUnban.Reason != "" {
+			shouldRedact := recs.BanOrUnban.Recommendation == event.PolicyRecommendationUnstableTakedown
+			if !shouldRedact && recs.BanOrUnban.Reason != "" {
 				for _, pattern := range pe.autoRedactPatterns {
 					if pattern.Match(recs.BanOrUnban.Reason) {
 						shouldRedact = true

--- a/policyeval/execute.go
+++ b/policyeval/execute.go
@@ -46,7 +46,16 @@ func (pe *PolicyEvaluator) ApplyPolicy(ctx context.Context, userID id.UserID, po
 			for _, room := range rooms {
 				pe.ApplyBan(ctx, userID, room, recs.BanOrUnban)
 			}
-			if recs.BanOrUnban.Reason == "spam" || recs.BanOrUnban.Recommendation == event.PolicyRecommendationUnstableTakedown {
+			shouldRedact := recs.BanOrUnban.Reason == "spam" || recs.BanOrUnban.Recommendation == event.PolicyRecommendationUnstableTakedown
+			if !shouldRedact && len(pe.autoRedactPatterns) > 0 && recs.BanOrUnban.Reason != "" {
+				for _, pattern := range pe.autoRedactPatterns {
+					if pattern.Match(recs.BanOrUnban.Reason) {
+						shouldRedact = true
+						break
+					}
+				}
+			}
+			if shouldRedact {
 				go pe.RedactUser(context.WithoutCancel(ctx), userID, recs.BanOrUnban.Reason, true)
 			}
 			if isNew {

--- a/policyeval/main.go
+++ b/policyeval/main.go
@@ -7,10 +7,9 @@ import (
 	"sync"
 	"time"
 
-	"go.mau.fi/util/glob"
-
 	"github.com/rs/zerolog"
 	"go.mau.fi/util/exsync"
+	"go.mau.fi/util/glob"
 	"maunium.net/go/mautrix"
 	"maunium.net/go/mautrix/event"
 	"maunium.net/go/mautrix/id"

--- a/policyeval/main.go
+++ b/policyeval/main.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"time"
 
+	"go.mau.fi/util/glob"
+
 	"github.com/rs/zerolog"
 	"go.mau.fi/util/exsync"
 	"maunium.net/go/mautrix"
@@ -58,6 +60,7 @@ type PolicyEvaluator struct {
 	AutoRejectInvites  bool
 	FilterLocalInvites bool
 	createPuppetClient func(userID id.UserID) *mautrix.Client
+	autoRedactPatterns []glob.Glob
 }
 
 func NewPolicyEvaluator(
@@ -69,6 +72,7 @@ func NewPolicyEvaluator(
 	claimProtected func(roomID id.RoomID, eval *PolicyEvaluator, claim bool) *PolicyEvaluator,
 	createPuppetClient func(userID id.UserID) *mautrix.Client,
 	autoRejectInvites, filterLocalInvites, dryRun bool,
+	hackyAutoRedactPatterns []glob.Glob,
 ) *PolicyEvaluator {
 	pe := &PolicyEvaluator{
 		Bot:                  bot,
@@ -89,6 +93,7 @@ func NewPolicyEvaluator(
 		AutoRejectInvites:    autoRejectInvites,
 		FilterLocalInvites:   filterLocalInvites,
 		DryRun:               dryRun,
+		autoRedactPatterns:   hackyAutoRedactPatterns,
 	}
 	return pe
 }


### PR DESCRIPTION
Allows reasons other than `spam` to trigger automatic redactions.