### PR TITLE
policyeval/execute: redact state events when redacting via history

### DIFF
--- a/policyeval/commands.go
+++ b/policyeval/commands.go
@@ -220,7 +220,7 @@ func (pe *PolicyEvaluator) HandleCommand(ctx context.Context, evt *event.Event) 
 			return
 		}
 		reason := strings.Join(args[2:], " ")
-		redactedCount, err := pe.redactRecentMessages(ctx, room, "", since, reason)
+		redactedCount, err := pe.redactRecentMessages(ctx, room, "", since, false, reason)
 		if err != nil {
 			pe.sendNotice(ctx, "Failed to redact recent messages: %v", err)
 			return


### PR DESCRIPTION
When a user is banned, their messages are redacted when iterating over /messages, but *not* their membership and other state events. This PR changes this, which brings behaviour in line with typical expectations.