### PR TITLE
policyeval: Implement MSC4284 policy server

### DIFF
--- a/cmd/meowlnir/http.go
+++ b/cmd/meowlnir/http.go
@@ -29,7 +29,9 @@ func (m *Meowlnir) AddHTTPEndpoints() {
 		http.StripPrefix("/_matrix/policy", policyServerRouter),
 		hlog.NewHandler(m.Log.With().Str("component", "policy server").Logger()),
 		hlog.RequestIDHandler("request_id", "X-Request-ID"),
-		requestlog.AccessLogger(false)))
+		requestlog.AccessLogger(false),
+		m.FederationAuth,
+	))
 
 	antispamRouter := http.NewServeMux()
 	antispamRouter.HandleFunc("POST /{policyListID}/{callback}", m.PostCallback)

--- a/cmd/meowlnir/http.go
+++ b/cmd/meowlnir/http.go
@@ -30,7 +30,7 @@ func (m *Meowlnir) AddHTTPEndpoints() {
 		hlog.NewHandler(m.Log.With().Str("component", "policy server").Logger()),
 		hlog.RequestIDHandler("request_id", "X-Request-ID"),
 		requestlog.AccessLogger(false),
-		m.FederationAuth,
+		m.PolicyServer.ServerAuth.AuthenticateMiddleware,
 	))
 
 	antispamRouter := http.NewServeMux()

--- a/cmd/meowlnir/http.go
+++ b/cmd/meowlnir/http.go
@@ -23,6 +23,14 @@ func (m *Meowlnir) AddHTTPEndpoints() {
 		m.ClientAuth,
 	))
 
+	policyServerRouter := http.NewServeMux()
+	policyServerRouter.HandleFunc("POST /unstable/org.matrix.msc4284/event/{event_id}/check", m.PostMSC4284EventCheck)
+	m.AS.Router.PathPrefix("/_matrix/policy").Handler(applyMiddleware(
+		http.StripPrefix("/_matrix/policy", policyServerRouter),
+		hlog.NewHandler(m.Log.With().Str("component", "policy server").Logger()),
+		hlog.RequestIDHandler("request_id", "X-Request-ID"),
+		requestlog.AccessLogger(false)))
+
 	antispamRouter := http.NewServeMux()
 	antispamRouter.HandleFunc("POST /{policyListID}/{callback}", m.PostCallback)
 	m.AS.Router.PathPrefix("/_meowlnir/antispam").Handler(applyMiddleware(

--- a/cmd/meowlnir/main.go
+++ b/cmd/meowlnir/main.go
@@ -11,8 +11,6 @@ import (
 	"sync"
 	"syscall"
 
-	"maunium.net/go/mautrix/federation"
-
 	_ "github.com/lib/pq"
 	"github.com/rs/zerolog"
 	up "go.mau.fi/util/configupgrade"
@@ -172,9 +170,7 @@ func (m *Meowlnir) Init(configPath string, noSaveConfig bool) {
 		compiledGlobs = append(compiledGlobs, compiled)
 	}
 	m.HackyAutoRedactPatterns = compiledGlobs
-	m.PolicyServer = &policyeval.PolicyServer{
-		Federation: federation.NewClient("meowlnir.localhost", nil, federation.NewInMemoryCache()),
-	}
+	m.PolicyServer = policyeval.NewPolicyServer()
 
 	m.Log.Info().Msg("Initialization complete")
 }

--- a/cmd/meowlnir/main.go
+++ b/cmd/meowlnir/main.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"syscall"
 
+	"maunium.net/go/mautrix/federation"
+
 	_ "github.com/lib/pq"
 	"github.com/rs/zerolog"
 	up "go.mau.fi/util/configupgrade"
@@ -170,6 +172,9 @@ func (m *Meowlnir) Init(configPath string, noSaveConfig bool) {
 		compiledGlobs = append(compiledGlobs, compiled)
 	}
 	m.HackyAutoRedactPatterns = compiledGlobs
+	m.PolicyServer = &policyeval.PolicyServer{
+		Federation: federation.NewClient("meowlnir.localhost", nil, federation.NewInMemoryCache()),
+	}
 
 	m.Log.Info().Msg("Initialization complete")
 }

--- a/cmd/meowlnir/main.go
+++ b/cmd/meowlnir/main.go
@@ -52,6 +52,7 @@ type Meowlnir struct {
 	CryptoStoreDB  *dbutil.Database
 	AS             *appservice.AppService
 	EventProcessor *appservice.EventProcessor
+	PolicyServer   *policyeval.PolicyServer
 
 	ManagementSecret [32]byte
 	AntispamSecret   [32]byte
@@ -84,7 +85,6 @@ func (m *Meowlnir) loadSecret(secret string) [32]byte {
 func (m *Meowlnir) Init(configPath string, noSaveConfig bool) {
 	var err error
 	m.Config = loadConfig(configPath, noSaveConfig)
-
 	policylist.HackyRuleFilter = m.Config.Meowlnir.HackyRuleFilter
 	policylist.HackyRuleFilterHashes = exslices.CastFunc(policylist.HackyRuleFilter, func(s string) [32]byte {
 		return util.SHA256String(s)

--- a/cmd/meowlnir/main.go
+++ b/cmd/meowlnir/main.go
@@ -153,6 +153,7 @@ func (m *Meowlnir) Init(configPath string, noSaveConfig bool) {
 		m.Log.WithLevel(zerolog.FatalLevel).Err(err).Msg("Failed to create Matrix appservice")
 		os.Exit(13)
 	}
+	m.PolicyServer = policyeval.NewPolicyServer()
 	m.AS.Log = m.Log.With().Str("component", "matrix").Logger()
 	m.AS.StateStore = m.StateStore
 	m.EventProcessor = appservice.NewEventProcessor(m.AS)
@@ -170,7 +171,6 @@ func (m *Meowlnir) Init(configPath string, noSaveConfig bool) {
 		compiledGlobs = append(compiledGlobs, compiled)
 	}
 	m.HackyAutoRedactPatterns = compiledGlobs
-	m.PolicyServer = policyeval.NewPolicyServer()
 
 	m.Log.Info().Msg("Initialization complete")
 }

--- a/cmd/meowlnir/main.go
+++ b/cmd/meowlnir/main.go
@@ -238,6 +238,7 @@ func (m *Meowlnir) newPolicyEvaluator(bot *bot.Bot, roomID id.RoomID) *policyeva
 		m.Config.Antispam.FilterLocalInvites,
 		m.Config.Meowlnir.DryRun,
 		m.HackyAutoRedactPatterns,
+		m.PolicyServer,
 	)
 }
 

--- a/cmd/meowlnir/policyserver.go
+++ b/cmd/meowlnir/policyserver.go
@@ -6,57 +6,10 @@ import (
 
 	"github.com/rs/zerolog/hlog"
 	"maunium.net/go/mautrix"
-	"maunium.net/go/mautrix/federation"
 	"maunium.net/go/mautrix/id"
 
 	"go.mau.fi/meowlnir/util"
 )
-
-func (m *Meowlnir) FederationAuth(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if m.Config.PolicyServer.Auth {
-			auth := federation.ParseXMatrixAuth(r.Header.Get("Authorization"))
-			if auth.Origin == "" {
-				hlog.FromRequest(r).Error().Msg("Missing origin in X-Matrix header")
-				mautrix.MForbidden.WithMessage("Policy Server error: missing origin").Write(w)
-				return
-			}
-
-			var body []byte
-			if r.Body != nil {
-				_, err := r.Body.Read(body)
-				if err != nil {
-					hlog.FromRequest(r).Err(err).Msg("Failed to read request body")
-					mautrix.MUnknown.WithMessage("Policy Server error: invalid request body").Write(w)
-					return
-				}
-			}
-			keys, err := m.PolicyServer.Federation.ServerKeys(r.Context(), auth.Origin)
-			if err != nil {
-				hlog.FromRequest(r).Err(err).Msg("Failed to query keys")
-				mautrix.MForbidden.WithMessage("Policy Server error: unknown signing key").Write(w)
-				return
-			}
-			hlog.FromRequest(r).Trace().Interface("keys_response", keys).Msg("Got keys response")
-			if !keys.HasKey(auth.KeyID) {
-				hlog.FromRequest(r).Err(err).
-					Interface("verify_keys", keys.VerifyKeys).
-					Stringer("wanted_key", auth.KeyID).
-					Msg("Failed to verify key")
-				mautrix.MForbidden.WithMessage("Policy Server error: invalid/expired signing key").Write(w)
-				return
-			}
-			key := keys.VerifyKeys[auth.KeyID].Key
-			if !federation.VerifyJSON(auth.Origin, auth.KeyID, key, body) {
-				hlog.FromRequest(r).Err(err).Msg("Failed to verify signature")
-				mautrix.MForbidden.WithMessage("Policy Server error: invalid signature").Write(w)
-				return
-			}
-		}
-
-		next.ServeHTTP(w, r)
-	})
-}
 
 func (m *Meowlnir) PostMSC4284EventCheck(w http.ResponseWriter, r *http.Request) {
 	eventID := id.EventID(r.PathValue("event_id"))

--- a/cmd/meowlnir/policyserver.go
+++ b/cmd/meowlnir/policyserver.go
@@ -5,11 +5,65 @@ import (
 	"net/http"
 
 	"github.com/rs/zerolog/hlog"
+	"go.mau.fi/util/jsontime"
 	"maunium.net/go/mautrix"
+	"maunium.net/go/mautrix/federation"
 	"maunium.net/go/mautrix/id"
 
 	"go.mau.fi/meowlnir/util"
 )
+
+func (m *Meowlnir) FederationAuth(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if m.Config.PolicyServer.SigningKey != nil && *m.Config.PolicyServer.SigningKey != "" {
+			ourKey, err := federation.ParseSynapseKey(*m.Config.PolicyServer.SigningKey)
+			if err != nil {
+				hlog.FromRequest(r).Err(err).Msg("Failed to parse our own signing key")
+				mautrix.MUnknown.WithMessage("Policy Server error: invalid signing key").Write(w)
+				return
+			}
+			auth := federation.ParseXMatrixAuth(r.Header.Get("X-Matrix"))
+			var body []byte
+			if r.Body != nil {
+				_, err = r.Body.Read(body)
+				if err != nil {
+					hlog.FromRequest(r).Err(err).Msg("Failed to read request body")
+					mautrix.MUnknown.WithMessage("Policy Server error: invalid request body").Write(w)
+					return
+				}
+			}
+			client := federation.NewClient("meowlnir", ourKey, federation.NewInMemoryCache())
+			ask := &federation.ReqQueryKeys{
+				ServerKeys: map[string]map[id.KeyID]federation.QueryKeysCriteria{
+					auth.Origin: {
+						auth.KeyID: {
+							MinimumValidUntilTS: jsontime.UnixMilliNow(),
+						},
+					},
+				},
+			}
+			keys, err := client.QueryKeys(r.Context(), auth.Origin, ask)
+			if err != nil {
+				hlog.FromRequest(r).Err(err).Msg("Failed to query keys")
+				mautrix.MForbidden.WithMessage("Policy Server error: unknown signing key").Write(w)
+				return
+			}
+			key, ok := keys.VerifyKeys[auth.KeyID]
+			if !ok {
+				hlog.FromRequest(r).Err(err).Msg("Failed to verify key")
+				mautrix.MForbidden.WithMessage("Policy Server error: invalid/expired signing key").Write(w)
+				return
+			}
+			if !federation.VerifyJSONRaw(key.Key, auth.Signature, body) {
+				hlog.FromRequest(r).Err(err).Msg("Failed to verify signature")
+				mautrix.MForbidden.WithMessage("Policy Server error: invalid signature").Write(w)
+				return
+			}
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
 
 func (m *Meowlnir) PostMSC4284EventCheck(w http.ResponseWriter, r *http.Request) {
 	eventID := id.EventID(r.PathValue("event_id"))

--- a/cmd/meowlnir/policyserver.go
+++ b/cmd/meowlnir/policyserver.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/rs/zerolog/hlog"
+	"maunium.net/go/mautrix"
+	"maunium.net/go/mautrix/id"
+
+	"go.mau.fi/meowlnir/util"
+)
+
+func (m *Meowlnir) PostMSC4284EventCheck(w http.ResponseWriter, r *http.Request) {
+	eventID := id.EventID(r.PathValue("event_id"))
+	var req util.EventPDU
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		hlog.FromRequest(r).Err(err).Msg("Failed to parse request body")
+		mautrix.MNotJSON.WithMessage("Policy Server request error: invalid JSON").Write(w)
+		return
+	}
+
+	m.MapLock.RLock()
+	eval, ok := m.EvaluatorByProtectedRoom[req.RoomID]
+	m.MapLock.RUnlock()
+	if !ok {
+		mautrix.MNotFound.WithMessage("Antispam configuration issue: policy list not found").Write(w)
+		return
+	}
+	resp, err := m.PolicyServer.HandleCheck(r.Context(), eventID, &req, eval)
+	if err != nil {
+		hlog.FromRequest(r).Err(err).Msg("Failed to handle check")
+		mautrix.MUnknown.WithMessage("Policy Server error: internal server error").Write(w)
+		return
+	}
+	err = json.NewEncoder(w).Encode(resp)
+	if err != nil {
+		hlog.FromRequest(r).Err(err).Msg("Failed to encode response")
+		mautrix.MNotJSON.WithMessage("Policy Server error: invalid JSON").Write(w)
+		return
+	}
+}

--- a/cmd/meowlnir/policyserver.go
+++ b/cmd/meowlnir/policyserver.go
@@ -75,7 +75,7 @@ func (m *Meowlnir) PostMSC4284EventCheck(w http.ResponseWriter, r *http.Request)
 		mautrix.MNotFound.WithMessage("Antispam configuration issue: policy list not found").Write(w)
 		return
 	}
-	resp, err := m.PolicyServer.HandleCheck(r.Context(), eventID, &req, eval)
+	resp, err := m.PolicyServer.HandleCheck(r.Context(), eventID, &req, eval, m.Config.PolicyServer.AlwaysRedact)
 	if err != nil {
 		hlog.FromRequest(r).Err(err).Msg("Failed to handle check")
 		mautrix.MUnknown.WithMessage("Policy Server error: internal server error").Write(w)

--- a/cmd/meowlnir/policyserver.go
+++ b/cmd/meowlnir/policyserver.go
@@ -34,6 +34,7 @@ func (m *Meowlnir) PostMSC4284EventCheck(w http.ResponseWriter, r *http.Request)
 		mautrix.MUnknown.WithMessage("Policy Server error: internal server error").Write(w)
 		return
 	}
+	w.Header().Set("Content-Type", "application/json")
 	err = json.NewEncoder(w).Encode(resp)
 	if err != nil {
 		hlog.FromRequest(r).Err(err).Msg("Failed to encode response")

--- a/config/config.go
+++ b/config/config.go
@@ -45,7 +45,6 @@ type EncryptionConfig struct {
 }
 
 type PolicyServerConfig struct {
-	Auth         bool `yaml:"auth"`
 	AlwaysRedact bool `yaml:"always_redact"`
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -45,7 +45,7 @@ type EncryptionConfig struct {
 }
 
 type PolicyServerConfig struct {
-	SigningKey *string `yaml:"signing_key"`
+	Auth bool `yaml:"auth"`
 }
 
 type Config struct {

--- a/config/config.go
+++ b/config/config.go
@@ -45,7 +45,8 @@ type EncryptionConfig struct {
 }
 
 type PolicyServerConfig struct {
-	Auth bool `yaml:"auth"`
+	Auth         bool `yaml:"auth"`
+	AlwaysRedact bool `yaml:"always_redact"`
 }
 
 type Config struct {

--- a/config/config.go
+++ b/config/config.go
@@ -44,12 +44,17 @@ type EncryptionConfig struct {
 	PickleKey string `yaml:"pickle_key"`
 }
 
+type PolicyServerConfig struct {
+	SigningKey *string `yaml:"signing_key"`
+}
+
 type Config struct {
-	Homeserver HomeserverConfig  `yaml:"homeserver"`
-	Meowlnir   MeowlnirConfig    `yaml:"meowlnir"`
-	Antispam   AntispamConfig    `yaml:"antispam"`
-	Encryption EncryptionConfig  `yaml:"encryption"`
-	Database   dbutil.Config     `yaml:"database"`
-	SynapseDB  dbutil.Config     `yaml:"synapse_db"`
-	Logging    zeroconfig.Config `yaml:"logging"`
+	Homeserver   HomeserverConfig   `yaml:"homeserver"`
+	Meowlnir     MeowlnirConfig     `yaml:"meowlnir"`
+	Antispam     AntispamConfig     `yaml:"antispam"`
+	Encryption   EncryptionConfig   `yaml:"encryption"`
+	Database     dbutil.Config      `yaml:"database"`
+	SynapseDB    dbutil.Config      `yaml:"synapse_db"`
+	Logging      zeroconfig.Config  `yaml:"logging"`
+	PolicyServer PolicyServerConfig `yaml:"policy_server"`
 }

--- a/config/example-config.yaml
+++ b/config/example-config.yaml
@@ -92,7 +92,11 @@ synapse_db:
 
 # Configuration for the policy server.
 policy_server:
-    auth: true  # false to not require federation authentication
+    # Enables or disables federation authentication and signature verification (recommended)
+    auth: true
+    # If enabled, always issue redactions for events that are blocked by the policy server.
+    # This is useful to prevent failed events from reaching servers that do not yet respect policy servers.
+    always_redact: true
 
 # Logging config. See https://github.com/tulir/zeroconfig for details.
 logging:

--- a/config/example-config.yaml
+++ b/config/example-config.yaml
@@ -92,8 +92,6 @@ synapse_db:
 
 # Configuration for the policy server.
 policy_server:
-    # Enables or disables federation authentication and signature verification (recommended)
-    auth: true
     # If enabled, always issue redactions for events that are blocked by the policy server.
     # This is useful to prevent failed events from reaching servers that do not yet respect policy servers.
     always_redact: true

--- a/config/example-config.yaml
+++ b/config/example-config.yaml
@@ -90,6 +90,12 @@ synapse_db:
     max_conn_idle_time: null
     max_conn_lifetime: null
 
+# Configuration for the policy server.
+# Right now, you only need to copy your Synapse signing key here, to enable authentication.
+# By default, policy requests are unauthenticated.
+policy_server:
+    signing_key:
+
 # Logging config. See https://github.com/tulir/zeroconfig for details.
 logging:
     min_level: debug

--- a/config/example-config.yaml
+++ b/config/example-config.yaml
@@ -91,10 +91,8 @@ synapse_db:
     max_conn_lifetime: null
 
 # Configuration for the policy server.
-# Right now, you only need to copy your Synapse signing key here, to enable authentication.
-# By default, policy requests are unauthenticated.
 policy_server:
-    signing_key:
+    auth: true  # false to not require federation authentication
 
 # Logging config. See https://github.com/tulir/zeroconfig for details.
 logging:

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	go.mau.fi/zeroconfig v0.1.3
 	gopkg.in/yaml.v3 v3.0.1
 	maunium.net/go/mauflag v1.0.0
-	maunium.net/go/mautrix v0.23.4-0.20250503000031-441349efac9e
+	maunium.net/go/mautrix v0.23.4-0.20250510083506-f23fc99ef40d
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -96,5 +96,5 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 maunium.net/go/mauflag v1.0.0 h1:YiaRc0tEI3toYtJMRIfjP+jklH45uDHtT80nUamyD4M=
 maunium.net/go/mauflag v1.0.0/go.mod h1:nLivPOpTpHnpzEh8jEdSL9UqO9+/KBJFmNRlwKfkPeA=
-maunium.net/go/mautrix v0.23.4-0.20250503000031-441349efac9e h1:eJkcIFqvLSb2zsVlQg4WHdf8QFJk2ty1i+07Rfh9B50=
-maunium.net/go/mautrix v0.23.4-0.20250503000031-441349efac9e/go.mod h1:pT4G5RZQ+nLfKzsmeDa4NhHghOVTrasLLwY9tZ2mO08=
+maunium.net/go/mautrix v0.23.4-0.20250510083506-f23fc99ef40d h1:e1PfPO2Bm4SK6t02eTRsSGkJy2bbx+02MEdK6XvgHng=
+maunium.net/go/mautrix v0.23.4-0.20250510083506-f23fc99ef40d/go.mod h1:pT4G5RZQ+nLfKzsmeDa4NhHghOVTrasLLwY9tZ2mO08=

--- a/policyeval/main.go
+++ b/policyeval/main.go
@@ -67,6 +67,7 @@ type PolicyEvaluator struct {
 	FilterLocalInvites bool
 	createPuppetClient func(userID id.UserID) *mautrix.Client
 	autoRedactPatterns []glob.Glob
+	policyServer       *PolicyServer
 }
 
 func NewPolicyEvaluator(
@@ -79,6 +80,7 @@ func NewPolicyEvaluator(
 	createPuppetClient func(userID id.UserID) *mautrix.Client,
 	autoRejectInvites, filterLocalInvites, dryRun bool,
 	hackyAutoRedactPatterns []glob.Glob,
+	policyServer *PolicyServer,
 ) *PolicyEvaluator {
 	pe := &PolicyEvaluator{
 		Bot:                  bot,
@@ -102,6 +104,7 @@ func NewPolicyEvaluator(
 		FilterLocalInvites:   filterLocalInvites,
 		DryRun:               dryRun,
 		autoRedactPatterns:   hackyAutoRedactPatterns,
+		policyServer:         policyServer,
 	}
 	pe.commandProcessor.LogArgs = true
 	pe.commandProcessor.Meta = pe

--- a/policyeval/policyserver.go
+++ b/policyeval/policyserver.go
@@ -24,8 +24,22 @@ type psCacheEntry struct {
 
 type PolicyServer struct {
 	Federation *federation.Client
+	ServerAuth *federation.ServerAuth
 	EventCache map[id.EventID]psCacheEntry
 	cacheLock  *sync.RWMutex
+}
+
+func NewPolicyServer() *PolicyServer {
+	inMemCache := federation.NewInMemoryCache()
+	fed := federation.NewClient("meowlnir.localhost", nil, inMemCache)
+	return &PolicyServer{
+		EventCache: make(map[id.EventID]psCacheEntry),
+		cacheLock:  &sync.RWMutex{},
+		Federation: fed,
+		ServerAuth: federation.NewServerAuth(fed, inMemCache, func(auth federation.XMatrixAuth) string {
+			return auth.Destination
+		}),
+	}
 }
 
 func (ps *PolicyServer) getCachedRecommendation(evtID id.EventID) (*PolicyServerResponse, bool) {

--- a/policyeval/policyserver.go
+++ b/policyeval/policyserver.go
@@ -3,16 +3,17 @@ package policyeval
 import (
 	"context"
 
-	"github.com/rs/zerolog"
-	"maunium.net/go/mautrix/event"
-	"maunium.net/go/mautrix/federation"
 	"maunium.net/go/mautrix/id"
+
+	"go.mau.fi/meowlnir/util"
+
+	"github.com/rs/zerolog"
+	"maunium.net/go/mautrix/federation"
 
 	"go.mau.fi/meowlnir/policylist"
 )
 
 type PolicyServer struct {
-	Evaluator  *PolicyEvaluator
 	Federation *federation.Client
 	Auth       *federation.ServerAuth
 }
@@ -33,54 +34,31 @@ var (
 	respPSSpam = &PolicyServerResponse{Recommendation: PSRecommendationSpam}
 )
 
-type EventPDU struct {
-	AuthEvents []id.EventID `json:"auth_events"`
-	Content    *event.Event `json:"content"`
-	Depth      int64        `json:"depth"`
-	Hashes     struct {
-		Sha256 string `json:"sha256"`
-	} `json:"hashes"`
-	OriginServerTS int64                        `json:"origin_server_ts"`
-	PrevEvents     []id.EventID                 `json:"prev_events"`
-	RoomID         id.RoomID                    `json:"room_id"`
-	Sender         id.UserID                    `json:"sender"`
-	Signatures     map[string]map[string]string `json:"signatures"`
-	StateKey       *string                      `json:"state_key"`
-	Type           event.Type                   `json:"type"`
-	Unsigned       *event.Unsigned              `json:"unsigned"`
-}
-
 // MSC4284: https://github.com/matrix-org/matrix-spec-proposals/pull/4284
 
-func (srv *PolicyServer) HandleCheck(ctx context.Context, pdu *event.Event) (*PolicyServerResponse, error) {
+func (srv *PolicyServer) HandleCheck(ctx context.Context, evtID id.EventID, pdu *util.EventPDU, evaluator *PolicyEvaluator) (*PolicyServerResponse, error) {
 	var match policylist.Match
-	logger := zerolog.Ctx(ctx).With().Stringer("room_id", pdu.RoomID).Stringer("event_id", pdu.ID).Logger()
-	srv.Evaluator.protectedRoomsLock.RLock()
-	_, protected := srv.Evaluator.protectedRooms[pdu.RoomID]
-	srv.Evaluator.protectedRoomsLock.RUnlock()
-	if !protected {
-		logger.Trace().Msg("received check for unprotected room")
-		return respPSOk, nil
-	}
+	logger := zerolog.Ctx(ctx).With().Stringer("room_id", pdu.RoomID).Stringer("event_id", evtID).Logger()
 	logger.Trace().Interface("event", pdu).Msg("received check for protected room")
 
-	watchedLists := srv.Evaluator.GetWatchedLists()
-	match = srv.Evaluator.Store.MatchUser(watchedLists, pdu.Sender)
+	watchedLists := evaluator.GetWatchedLists()
+	match = evaluator.Store.MatchUser(watchedLists, pdu.Sender)
 	if match != nil {
 		logger.Warn().Stringer("recommendations", match.Recommendations()).Msg("event rejected for spam")
 		return respPSSpam, nil
 	}
-	match = srv.Evaluator.Store.MatchServer(watchedLists, pdu.Sender.Homeserver())
+	match = evaluator.Store.MatchServer(watchedLists, pdu.Sender.Homeserver())
 	if match != nil {
 		logger.Warn().Stringer("recommendations", match.Recommendations()).Msg("event rejected for spam")
 		return respPSSpam, nil
 	}
 	// In theory, if a room is taken down and uses the policy server, we can prevent them sending further events
-	match = srv.Evaluator.Store.MatchRoom(watchedLists, pdu.RoomID)
+	match = evaluator.Store.MatchRoom(watchedLists, pdu.RoomID)
 	if match != nil {
 		logger.Warn().Stringer("recommendations", match.Recommendations()).Msg("event rejected for spam")
 		return respPSSpam, nil
 	}
+	// todo, in future, check against protections?
 
 	// Seems fine.
 	logger.Trace().Msg("event accepted")

--- a/policyeval/policyserver.go
+++ b/policyeval/policyserver.go
@@ -1,0 +1,88 @@
+package policyeval
+
+import (
+	"context"
+
+	"github.com/rs/zerolog"
+	"maunium.net/go/mautrix/event"
+	"maunium.net/go/mautrix/federation"
+	"maunium.net/go/mautrix/id"
+
+	"go.mau.fi/meowlnir/policylist"
+)
+
+type PolicyServer struct {
+	Evaluator  *PolicyEvaluator
+	Federation *federation.Client
+	Auth       *federation.ServerAuth
+}
+
+type PSRecommendation string
+
+const (
+	PSRecommendationOk   PSRecommendation = "ok"
+	PSRecommendationSpam PSRecommendation = "spam"
+)
+
+type PolicyServerResponse struct {
+	Recommendation PSRecommendation `json:"recommendation"`
+}
+
+var (
+	respPSOk   = &PolicyServerResponse{Recommendation: PSRecommendationOk}
+	respPSSpam = &PolicyServerResponse{Recommendation: PSRecommendationSpam}
+)
+
+type EventPDU struct {
+	AuthEvents []id.EventID `json:"auth_events"`
+	Content    *event.Event `json:"content"`
+	Depth      int64        `json:"depth"`
+	Hashes     struct {
+		Sha256 string `json:"sha256"`
+	} `json:"hashes"`
+	OriginServerTS int64                        `json:"origin_server_ts"`
+	PrevEvents     []id.EventID                 `json:"prev_events"`
+	RoomID         id.RoomID                    `json:"room_id"`
+	Sender         id.UserID                    `json:"sender"`
+	Signatures     map[string]map[string]string `json:"signatures"`
+	StateKey       *string                      `json:"state_key"`
+	Type           event.Type                   `json:"type"`
+	Unsigned       *event.Unsigned              `json:"unsigned"`
+}
+
+// MSC4284: https://github.com/matrix-org/matrix-spec-proposals/pull/4284
+
+func (srv *PolicyServer) HandleCheck(ctx context.Context, pdu *event.Event) (*PolicyServerResponse, error) {
+	var match policylist.Match
+	logger := zerolog.Ctx(ctx).With().Stringer("room_id", pdu.RoomID).Stringer("event_id", pdu.ID).Logger()
+	srv.Evaluator.protectedRoomsLock.RLock()
+	_, protected := srv.Evaluator.protectedRooms[pdu.RoomID]
+	srv.Evaluator.protectedRoomsLock.RUnlock()
+	if !protected {
+		logger.Trace().Msg("received check for unprotected room")
+		return respPSOk, nil
+	}
+	logger.Trace().Interface("event", pdu).Msg("received check for protected room")
+
+	watchedLists := srv.Evaluator.GetWatchedLists()
+	match = srv.Evaluator.Store.MatchUser(watchedLists, pdu.Sender)
+	if match != nil {
+		logger.Warn().Stringer("recommendations", match.Recommendations()).Msg("event rejected for spam")
+		return respPSSpam, nil
+	}
+	match = srv.Evaluator.Store.MatchServer(watchedLists, pdu.Sender.Homeserver())
+	if match != nil {
+		logger.Warn().Stringer("recommendations", match.Recommendations()).Msg("event rejected for spam")
+		return respPSSpam, nil
+	}
+	// In theory, if a room is taken down and uses the policy server, we can prevent them sending further events
+	match = srv.Evaluator.Store.MatchRoom(watchedLists, pdu.RoomID)
+	if match != nil {
+		logger.Warn().Stringer("recommendations", match.Recommendations()).Msg("event rejected for spam")
+		return respPSSpam, nil
+	}
+
+	// Seems fine.
+	logger.Trace().Msg("event accepted")
+	return respPSOk, nil
+}

--- a/policyeval/policyserver.go
+++ b/policyeval/policyserver.go
@@ -15,7 +15,6 @@ import (
 
 type PolicyServer struct {
 	Federation *federation.Client
-	Auth       *federation.ServerAuth
 }
 
 type PSRecommendation string

--- a/util/pdu.go
+++ b/util/pdu.go
@@ -1,0 +1,23 @@
+package util
+
+import (
+	"maunium.net/go/mautrix/event"
+	"maunium.net/go/mautrix/id"
+)
+
+type EventPDU struct {
+	AuthEvents []id.EventID `json:"auth_events"`
+	Content    *event.Event `json:"content"`
+	Depth      int64        `json:"depth"`
+	Hashes     struct {
+		Sha256 string `json:"sha256"`
+	} `json:"hashes"`
+	OriginServerTS int64                        `json:"origin_server_ts"`
+	PrevEvents     []id.EventID                 `json:"prev_events"`
+	RoomID         id.RoomID                    `json:"room_id"`
+	Sender         id.UserID                    `json:"sender"`
+	Signatures     map[string]map[string]string `json:"signatures"`
+	StateKey       *string                      `json:"state_key"`
+	Type           event.Type                   `json:"type"`
+	Unsigned       *event.Unsigned              `json:"unsigned"`
+}


### PR DESCRIPTION
This PR implements a standalone [policy server](https://github.com/matrix-org/matrix-spec-proposals/pull/4284) which fully supports and has been tested using the Synapse [policyserv_spam_checker](https://github.com/element-hq/policyserv_spam_checker) module.

To set it up, all you need to do is pass the `/_matrix/policy/unstable/org.matrix.msc4284/event/{event_id}/check` endpoint through to Meowlnir in the reverse proxy. Meowlnir will work out which policies to apply based on the room the PDU was sent in. Optionally, Meowlnir can be configured to send automatic redactions for events that fail the check.
Meowlnir must be joined to, and the PDU sent in a protected room, in order for this to work.

An example server has been deployed at nexy7574.co.uk, and has been working seamlessly in my rooms so far.