### PR TITLE
policyeval: Use spoilers to hide potentially sensitive entity names

### DIFF
--- a/policyeval/antispam.go
+++ b/policyeval/antispam.go
@@ -47,7 +47,7 @@ func (pe *PolicyEvaluator) HandleUserMayInvite(ctx context.Context, inviter, inv
 		if rec != nil {
 			go pe.sendNotice(
 				context.WithoutCancel(ctx),
-				"Blocked [%s](%s) from inviting [%s](%s) to [%s](%s) due to policy banning `%s` for `%s`",
+				"Blocked ||[%s](%s)|| from inviting [%s](%s) to [%s](%s) due to policy banning ||`%s`|| for `%s`",
 				inviter, inviter.URI().MatrixToURL(),
 				invitee, invitee.URI().MatrixToURL(),
 				roomID, roomID.URI().MatrixToURL(),
@@ -128,7 +128,7 @@ func (pe *PolicyEvaluator) HandleAcceptMakeJoin(ctx context.Context, roomID id.R
 			Msg("Blocking restricted join from banned user")
 		go pe.sendNotice(
 			context.WithoutCancel(ctx),
-			"Blocked [%s](%s) from joining [%s](%s) due to policy banning `%s` for `%s`",
+			"Blocked ||[%s](%s)|| from joining [%s](%s) due to policy banning ||`%s`|| for `%s`",
 			userID, userID.URI().MatrixToURL(),
 			roomID, roomID.URI().MatrixToURL(),
 			rec.EntityOrHash(), rec.Reason,
@@ -227,7 +227,7 @@ func (pe *PolicyEvaluator) RejectPendingInvites(ctx context.Context, inviter id.
 		}
 		pe.sendNotice(
 			ctx,
-			"Rejected %d/%d invites to [%s](%s) from [%s](%s) due to policy banning `%s` for `%s`",
+			"Rejected %d/%d invites to [%s](%s) from ||[%s](%s)|| due to policy banning ||`%s`|| for `%s`",
 			successfullyRejected, len(rooms),
 			userID, userID.URI().MatrixToURL(),
 			inviter, inviter.URI().MatrixToURL(),

--- a/policyeval/eventhandle.go
+++ b/policyeval/eventhandle.go
@@ -129,19 +129,19 @@ func (pe *PolicyEvaluator) HandlePolicyListChange(ctx context.Context, policyRoo
 	if removedAndAddedAreEquivalent {
 		if removed.Reason == added.Reason {
 			sendNotice(ctx,
-				"[%s] [%s](%s) re-%s `%s` for `%s`",
+				"[%s] [%s](%s) re-%s ||`%s`|| for `%s`",
 				policyRoomMeta.Name, added.Sender, added.Sender.URI().MatrixToURL(),
 				addActionString(added.Recommendation), added.EntityOrHash(), added.Reason)
 		} else {
 			sendNotice(ctx,
-				"[%s] [%s](%s) changed the %s reason for `%s` from `%s` to `%s`",
+				"[%s] [%s](%s) changed the %s reason for ||`%s`|| from `%s` to `%s`",
 				policyRoomMeta.Name, added.Sender, added.Sender.URI().MatrixToURL(),
 				changeActionString(added.Recommendation), added.EntityOrHash(), removed.Reason, added.Reason)
 		}
 	} else {
 		if removed != nil {
 			sendNotice(ctx,
-				"[%s] [%s](%s) %s %ss matching `%s` for `%s`",
+				"[%s] [%s](%s) %s %ss matching ||`%s`|| for `%s`",
 				policyRoomMeta.Name, removed.Sender, removed.Sender.URI().MatrixToURL(),
 				removeActionString(removed.Recommendation), removed.EntityType, removed.EntityOrHash(), removed.Reason,
 			)
@@ -155,7 +155,7 @@ func (pe *PolicyEvaluator) HandlePolicyListChange(ctx context.Context, policyRoo
 				suffix = " (rule was ignored)"
 			}
 			sendNotice(ctx,
-				"[%s] [%s](%s) %s %ss matching `%s` for `%s`%s",
+				"[%s] [%s](%s) %s %ss matching ||`%s`|| for `%s`%s",
 				policyRoomMeta.Name, added.Sender, added.Sender.URI().MatrixToURL(),
 				addActionString(added.Recommendation), added.EntityType, added.EntityOrHash(), added.Reason,
 				suffix,

--- a/policyeval/execute.go
+++ b/policyeval/execute.go
@@ -123,16 +123,16 @@ func (pe *PolicyEvaluator) ApplyBan(ctx context.Context, userID id.UserID, roomI
 			err = respErr
 		}
 		zerolog.Ctx(ctx).Err(err).Any("attempted_action", ta).Msg("Failed to ban user")
-		pe.sendNotice(ctx, "Failed to ban [%s](%s) in [%s](%s) for %s: %v", userID, userID.URI().MatrixToURL(), roomID, roomID.URI().MatrixToURL(), policy.Reason, err)
+		pe.sendNotice(ctx, "Failed to ban ||[%s](%s)|| in [%s](%s) for %s: %v", userID, userID.URI().MatrixToURL(), roomID, roomID.URI().MatrixToURL(), policy.Reason, err)
 		return
 	}
 	err = pe.DB.TakenAction.Put(ctx, ta)
 	if err != nil {
 		zerolog.Ctx(ctx).Err(err).Any("taken_action", ta).Msg("Failed to save taken action")
-		pe.sendNotice(ctx, "Banned [%s](%s) in [%s](%s) for %s, but failed to save to database: %v", userID, userID.URI().MatrixToURL(), roomID, roomID.URI().MatrixToURL(), policy.Reason, err)
+		pe.sendNotice(ctx, "Banned ||[%s](%s)|| in [%s](%s) for %s, but failed to save to database: %v", userID, userID.URI().MatrixToURL(), roomID, roomID.URI().MatrixToURL(), policy.Reason, err)
 	} else {
 		zerolog.Ctx(ctx).Info().Any("taken_action", ta).Msg("Took action")
-		pe.sendNotice(ctx, "Banned [%s](%s) in [%s](%s) for %s", userID, userID.URI().MatrixToURL(), roomID, roomID.URI().MatrixToURL(), policy.Reason)
+		pe.sendNotice(ctx, "Banned ||[%s](%s)|| in [%s](%s) for %s", userID, userID.URI().MatrixToURL(), roomID, roomID.URI().MatrixToURL(), policy.Reason)
 	}
 }
 

--- a/policyeval/report.go
+++ b/policyeval/report.go
@@ -33,20 +33,20 @@ func (pe *PolicyEvaluator) HandleReport(ctx context.Context, senderClient *mautr
 	if !pe.Admins.Has(sender) || !strings.HasPrefix(reason, "/") || targetUserID == "" {
 		if eventID != "" {
 			pe.sendNotice(
-				ctx, `[%s](%s) reported [an event](%s) from [%s](%s) for %s`,
+				ctx, `[%s](%s) reported [an event](%s) from ||[%s](%s)|| for %s`,
 				sender, sender.URI().MatrixToURL(), roomID.EventURI(eventID).MatrixToURL(),
 				evt.Sender, evt.Sender.URI().MatrixToURL(),
 				reason,
 			)
 		} else if roomID != "" {
 			pe.sendNotice(
-				ctx, `[%s](%s) reported [a room](%s) for %s`,
+				ctx, `[%s](%s) reported ||[a room](%s)|| for %s`,
 				sender, sender.URI().MatrixToURL(), roomID.URI().MatrixToURL(),
 				reason,
 			)
 		} else if targetUserID != "" {
 			pe.sendNotice(
-				ctx, `[%s](%s) reported [%s](%s) for %s`,
+				ctx, `[%s](%s) reported ||[%s](%s)|| for %s`,
 				sender, sender.URI().MatrixToURL(), targetUserID.URI().MatrixToURL(),
 				reason,
 			)
@@ -90,7 +90,7 @@ func (pe *PolicyEvaluator) HandleReport(ctx context.Context, senderClient *mautr
 		}
 		resp, err := pe.SendPolicy(ctx, list.RoomID, policylist.EntityTypeUser, "", string(targetUserID), policy)
 		if err != nil {
-			pe.sendNotice(ctx, `Failed to handle [%s](%s)'s report of [%s](%s) for %s ([%s](%s)): %v`,
+			pe.sendNotice(ctx, `Failed to handle [%s](%s)'s report of ||[%s](%s)|| for %s ([%s](%s)): %v`,
 				sender, sender.URI().MatrixToURL(), targetUserID, targetUserID.URI().MatrixToURL(),
 				list.Name, list.RoomID, list.RoomID.URI().MatrixToURL(), err)
 			return fmt.Errorf("failed to send policy: %w", err)
@@ -100,7 +100,7 @@ func (pe *PolicyEvaluator) HandleReport(ctx context.Context, senderClient *mautr
 			Any("policy", policy).
 			Stringer("policy_event_id", resp.EventID).
 			Msg("Sent ban policy from report")
-		pe.sendNotice(ctx, `Processed [%s](%s)'s report of [%s](%s) and sent a ban policy to %s ([%s](%s)) for %s`,
+		pe.sendNotice(ctx, `Processed [%s](%s)'s report of ||[%s](%s)|| and sent a ban policy to %s ([%s](%s)) for %s`,
 			sender, sender.URI().MatrixToURL(), targetUserID, targetUserID.URI().MatrixToURL(),
 			list.Name, list.RoomID, list.RoomID.URI().MatrixToURL(), policy.Reason)
 	}


### PR DESCRIPTION
Reduces the impact of malicious usernames being added to policy lists without hashes. 
Assuming gomuks markdown is accepted here, which is what it looks like the SendNotice function does by default.