### PR TITLE
http.go: Fix room reporting endpoint

### DIFF
--- a/cmd/meowlnir/http.go
+++ b/cmd/meowlnir/http.go
@@ -12,7 +12,7 @@ import (
 func (m *Meowlnir) AddHTTPEndpoints() {
 	clientRouter := http.NewServeMux()
 	clientRouter.HandleFunc("POST /v3/rooms/{roomID}/report/{eventID}", m.PostReport)
-	clientRouter.HandleFunc("POST /v3/rooms/{roomID}", m.PostReport)
+	clientRouter.HandleFunc("POST /v3/rooms/{roomID}/report", m.PostReport)
 	clientRouter.HandleFunc("POST /v3/users/{userID}/report", m.PostReport)
 	m.AS.Router.PathPrefix("/_matrix/client").Handler(applyMiddleware(
 		http.StripPrefix("/_matrix/client", clientRouter),


### PR DESCRIPTION
We want to listen for
POST /_matrix/client/v3/rooms/{roomId}/report and not for POST /_matrix/client/v3/rooms/{roomId}

see https://spec.matrix.org/latest/client-server-api/#post_matrixclientv3roomsroomidreport