### PR TITLE
Add support for referencing rooms by matrix.to URL

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+.direnv
 
 *.yaml
 !.pre-commit-config.yaml

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1748281391,
+        "narHash": "sha256-fTll03tzUcgBrrMvD6O06TittBG2Ae6m3iW7aunxwPY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bdc995d3e97cec29eacc8fbe87e66edfea26b861",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,23 @@
+{
+    inputs = {
+        nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+        flake-utils.url = "github:numtide/flake-utils";
+    };
+
+    outputs = { nixpkgs, flake-utils, ... }:
+        flake-utils.lib.eachDefaultSystem (system: let
+            pkgs = import nixpkgs {
+                inherit system;
+                config.permittedInsecurePackages = [
+                    "olm-3.2.16"
+                ];
+            };
+        in {
+            devShells.default = pkgs.mkShell {
+                packages = with pkgs; [
+                    go_1_23
+                    olm
+                ];
+            };
+        });
+}


### PR DESCRIPTION
This makes it easier to reference rooms for the bot to join or protect, as some clients have special rendering and autofill for matrix.to links. I haven't programed in go before, so feel free to correct any of my ungolike code if I made any :)

I also added an extremely simple nix+direnv devshell as I use NixOS and needed it to develop, so hopefully adding it is also fine.