### PR TITLE
policyserver: don't redact non-ban recommendations

### DIFF
--- a/policyeval/policyserver.go
+++ b/policyeval/policyserver.go
@@ -94,11 +94,17 @@ func (ps *PolicyServer) getRecommendation(pdu *event.Event, evaluator *PolicyEva
 	watchedLists := evaluator.GetWatchedLists()
 	match := evaluator.Store.MatchUser(watchedLists, pdu.Sender)
 	if match != nil {
-		return PSRecommendationSpam, match
+		rec := match.Recommendations().BanOrUnban
+		if rec != nil && rec.Recommendation != event.PolicyRecommendationUnban {
+			return PSRecommendationSpam, match
+		}
 	}
 	match = evaluator.Store.MatchServer(watchedLists, pdu.Sender.Homeserver())
 	if match != nil {
-		return PSRecommendationSpam, match
+		rec := match.Recommendations().BanOrUnban
+		if rec != nil && rec.Recommendation != event.PolicyRecommendationUnban {
+			return PSRecommendationSpam, match
+		}
 	}
 	// TODO check protections
 	return PSRecommendationOk, nil


### PR DESCRIPTION
prevents meowlnir from nuking continuwuity offtopic after finding out that the bot itself has an unban recommendation (and treating it like a soft-ban)