### PR TITLE
policyeval/execute: Add capability to auto-suspend on prefix

### DIFF
--- a/config/event.go
+++ b/config/event.go
@@ -20,7 +20,7 @@ type WatchedPolicyList struct {
 	DontApplyACL      bool      `json:"dont_apply_acl"`
 	AutoUnban         bool      `json:"auto_unban"`
 	AutoSuspend       bool      `json:"auto_suspend"`
-	AutoSuspendPrefix *string   `json:"auto_suspend_prefix,omitempty"`
+	AutoSuspendPrefix string    `json:"auto_suspend_prefix"`
 
 	DontNotifyOnChange bool `json:"dont_notify_on_change"`
 }

--- a/config/event.go
+++ b/config/event.go
@@ -19,6 +19,7 @@ type WatchedPolicyList struct {
 	DontApply         bool      `json:"dont_apply"`
 	DontApplyACL      bool      `json:"dont_apply_acl"`
 	AutoUnban         bool      `json:"auto_unban"`
+	AutoSuspend       bool      `json:"auto_suspend"`
 	AutoSuspendPrefix *string   `json:"auto_suspend_prefix,omitempty"`
 
 	DontNotifyOnChange bool `json:"dont_notify_on_change"`

--- a/config/event.go
+++ b/config/event.go
@@ -13,13 +13,13 @@ var (
 )
 
 type WatchedPolicyList struct {
-	RoomID       id.RoomID `json:"room_id"`
-	Name         string    `json:"name"`
-	Shortcode    string    `json:"shortcode"`
-	DontApply    bool      `json:"dont_apply"`
-	DontApplyACL bool      `json:"dont_apply_acl"`
-	AutoUnban    bool      `json:"auto_unban"`
-	AutoSuspend  bool      `json:"auto_suspend"`
+	RoomID            id.RoomID `json:"room_id"`
+	Name              string    `json:"name"`
+	Shortcode         string    `json:"shortcode"`
+	DontApply         bool      `json:"dont_apply"`
+	DontApplyACL      bool      `json:"dont_apply_acl"`
+	AutoUnban         bool      `json:"auto_unban"`
+	AutoSuspendPrefix *string   `json:"auto_suspend_prefix,omitempty"`
 
 	DontNotifyOnChange bool `json:"dont_notify_on_change"`
 }

--- a/policyeval/execute.go
+++ b/policyeval/execute.go
@@ -136,10 +136,7 @@ func (pe *PolicyEvaluator) maybeApplySuspend(ctx context.Context, userID id.User
 		return
 	}
 	plist := pe.GetWatchedListMeta(policy.RoomID)
-	if !plist.AutoSuspend {
-		return
-	}
-	if plist.AutoSuspendPrefix != nil && !strings.HasPrefix(*plist.AutoSuspendPrefix, policy.Reason) {
+	if !plist.AutoSuspend || !strings.HasPrefix(plist.AutoSuspendPrefix, policy.Reason) {
 		return
 	}
 	err := pe.Bot.SynapseAdmin.SuspendAccount(ctx, userID, synapseadmin.ReqSuspendUser{Suspend: true})

--- a/policyeval/execute.go
+++ b/policyeval/execute.go
@@ -136,7 +136,7 @@ func (pe *PolicyEvaluator) maybeApplySuspend(ctx context.Context, userID id.User
 		return
 	}
 	plist := pe.GetWatchedListMeta(policy.RoomID)
-	if !plist.AutoSuspend {
+	if plist.AutoSuspendPrefix == nil || !strings.HasPrefix(*plist.AutoSuspendPrefix, policy.Reason) {
 		return
 	}
 	err := pe.Bot.SynapseAdmin.SuspendAccount(ctx, userID, synapseadmin.ReqSuspendUser{Suspend: true})

--- a/policyeval/execute.go
+++ b/policyeval/execute.go
@@ -136,7 +136,10 @@ func (pe *PolicyEvaluator) maybeApplySuspend(ctx context.Context, userID id.User
 		return
 	}
 	plist := pe.GetWatchedListMeta(policy.RoomID)
-	if plist.AutoSuspendPrefix == nil || !strings.HasPrefix(*plist.AutoSuspendPrefix, policy.Reason) {
+	if !plist.AutoSuspend {
+		return
+	}
+	if plist.AutoSuspendPrefix != nil && !strings.HasPrefix(*plist.AutoSuspendPrefix, policy.Reason) {
 		return
 	}
 	err := pe.Bot.SynapseAdmin.SuspendAccount(ctx, userID, synapseadmin.ReqSuspendUser{Suspend: true})


### PR DESCRIPTION
Allows only auto-suspending if a policy reason begins with a given prefix (such as `suspend: ` etc)