### PR TITLE
policyeval/commands: urlencode SendPolicy state key

### DIFF
--- a/policyeval/commands.go
+++ b/policyeval/commands.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"regexp"
 	"slices"
 	"strconv"
@@ -1101,5 +1102,6 @@ func (pe *PolicyEvaluator) SendPolicy(ctx context.Context, policyList id.RoomID,
 		stateKeyHash := sha256.Sum256(append([]byte(rawEntity), []byte(content.Recommendation)...))
 		stateKey = base64.StdEncoding.EncodeToString(stateKeyHash[:])
 	}
+	stateKey = url.PathEscape(stateKey)
 	return pe.Bot.SendStateEvent(ctx, policyList, entityType.EventType(), stateKey, content)
 }


### PR DESCRIPTION
Fixes
`2025-09-04T14:31:38.066Z DBG Request completed args=["--hash","...","...","...:","...","..."] command=takedown duration=1.501209 event_id=$... handler=["ban"] method=PUT req_body={"org.matrix.msc4205.hashes":{"sha256":"..."},"reason":"...","recommendation":"org.matrix.msc4204.takedown"} req_id=29 response_length=64 response_mime=application/json room_id=... sender=... status_code=404 url=http://unix/_matrix/client/v3/rooms/.../state/m.policy.rule.room/...?user_id=...` (404 because state key has an unescaped `/` in it)