### PR TITLE
policyeval: Add notice during init if dry run is enabled

### DIFF
--- a/policyeval/main.go
+++ b/policyeval/main.go
@@ -236,6 +236,9 @@ func (pe *PolicyEvaluator) tryLoad(ctx context.Context) error {
 			"Protecting %d rooms with %d users (%d all time) using %d lists.",
 			initDuration, evalDuration, protectedRoomsCount, joinedUserCount, userCount, len(pe.GetWatchedLists()))
 	}
+	if pe.policyServer.SigningKey != nil {
+		msg += fmt.Sprintf("\n\nPolicy server signatures are enabled with the public key `%s`.", pe.policyServer.SigningKey.Pub)
+	}
 	if pe.DryRun {
 		msg += "\n\n**Dry run mode is enabled, no actions will be taken.**"
 	}


### PR DESCRIPTION
<img width="1277" height="122" alt="image" src="https://github.com/user-attachments/assets/17c18d88-e28b-4e70-a7e3-135f8fe7d7bd" />

I remember someone at some point running with dry mode enabled without realising, so this just appends a message to the init status message to indicate if the bot is running in dry mode

This PR also informs management rooms of their policy server's public key during startup, since there's no other way to get it other than deriving the public key from the private key in the config manually.