### PR TITLE
WIP: policyeval/eventhandle: Add menu to write room un/bans to policy lists

### DIFF
--- a/policyeval/propagate.go
+++ b/policyeval/propagate.go
@@ -8,12 +8,13 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
-	"go.mau.fi/meowlnir/bot"
-	"go.mau.fi/meowlnir/config"
 	"maunium.net/go/mautrix/commands"
 	"maunium.net/go/mautrix/event"
 	"maunium.net/go/mautrix/format"
 	"maunium.net/go/mautrix/id"
+
+	"go.mau.fi/meowlnir/bot"
+	"go.mau.fi/meowlnir/config"
 )
 
 func (pe *PolicyEvaluator) writableLists(ctx context.Context) map[id.RoomID]*config.WatchedPolicyList {

--- a/policyeval/propagate.go
+++ b/policyeval/propagate.go
@@ -1,0 +1,114 @@
+package policyeval
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"slices"
+	"time"
+
+	"github.com/rs/zerolog"
+	"go.mau.fi/meowlnir/bot"
+	"go.mau.fi/meowlnir/config"
+	"maunium.net/go/mautrix/commands"
+	"maunium.net/go/mautrix/event"
+	"maunium.net/go/mautrix/format"
+	"maunium.net/go/mautrix/id"
+)
+
+func (pe *PolicyEvaluator) writableLists(ctx context.Context) map[id.RoomID]*config.WatchedPolicyList {
+	lists := make(map[id.RoomID]*config.WatchedPolicyList)
+	for roomID, list := range pe.watchedListsMap {
+		if list.Shortcode == "" {
+			continue
+		}
+		pl, err := pe.Bot.StateStore.GetPowerLevels(ctx, roomID)
+		if err != nil || pl.GetEventLevel(event.StatePolicyUser) > pl.GetUserLevel(pe.Bot.UserID) {
+			continue
+		}
+		lists[roomID] = list
+	}
+	return lists
+}
+
+func (pe *PolicyEvaluator) propagateBan(ctx context.Context, banEvent *event.Event) {
+	content := banEvent.Content.AsMember()
+	userID := id.UserID(banEvent.GetStateKey())
+	actions := make(map[string]any, len(pe.watchedListsMap))
+	for _, list := range pe.writableLists(ctx) {
+		actions["/ban "+list.Shortcode] = fmt.Sprintf("!ban %s %s %s", list.Shortcode, userID, content.Reason)
+		continue
+	}
+	if len(actions) == 0 {
+		zerolog.Ctx(ctx).Debug().Msg("No writable policy lists to propagate ban to")
+		return
+	}
+
+	msg := fmt.Sprintf(
+		"%s was banned from %s by %s%s for %s. Copy to a policy list?",
+		format.MarkdownMention(userID),
+		format.MarkdownMentionRoomID("", banEvent.RoomID),
+		format.MarkdownMention(banEvent.Sender),
+		oldEventNotice(banEvent.Timestamp),
+		format.SafeMarkdownCode(content.Reason),
+	)
+	evtID := pe.Bot.SendNoticeOpts(ctx, pe.ManagementRoom, msg, &bot.SendNoticeOpts{
+		Extra: map[string]any{commands.ReactionCommandsKey: actions},
+	})
+	if evtID == "" {
+		return
+	}
+	pe.sendReactions(ctx, evtID, slices.Collect(maps.Keys(actions))...)
+}
+func (pe *PolicyEvaluator) propagateUnban(ctx context.Context, unbanEvent *event.Event) {
+	content := unbanEvent.Content.AsMember()
+	userID := id.UserID(unbanEvent.GetStateKey())
+
+	match := pe.Store.MatchUser(pe.GetWatchedLists(), userID)
+	if len(match) == 0 {
+		zerolog.Ctx(ctx).Debug().Msg("No matching policies to propagate unban to")
+		return
+	}
+
+	actions := make(map[string]any, len(match))
+	writeable := pe.writableLists(ctx)
+	msg := fmt.Sprintf(
+		"%s was unbanned from %s by %s%s for %s, but is still banned by %d policies. Do you want to remove any?\n",
+		format.MarkdownMention(userID),
+		format.MarkdownMentionRoomID("", unbanEvent.RoomID),
+		format.MarkdownMention(unbanEvent.Sender),
+		oldEventNotice(unbanEvent.Timestamp),
+		format.SafeMarkdownCode(content.Reason),
+		len(match),
+	)
+	n := 0
+	for _, policy := range match {
+		meta, ok := writeable[policy.RoomID]
+		if !ok {
+			continue
+		}
+		n++
+		msg += fmt.Sprintf(
+			"%d. [%s] %s set recommendation %s for %s at %s for %s",
+			n,
+			format.EscapeMarkdown(meta.Shortcode),
+			format.MarkdownMention(policy.Sender),
+			format.SafeMarkdownCode(policy.Recommendation),
+			format.SafeMarkdownCode(policy.EntityOrHash()),
+			format.EscapeMarkdown(time.UnixMilli(policy.Timestamp).String()),
+			format.SafeMarkdownCode(policy.Reason),
+		)
+		actions[fmt.Sprintf("/remove %d", n)] = fmt.Sprintf("!remove-policy %s %s", meta.Shortcode, policy.EntityOrHash())
+	}
+	if len(actions) == 0 {
+		return
+	}
+
+	evtID := pe.Bot.SendNoticeOpts(ctx, pe.ManagementRoom, msg, &bot.SendNoticeOpts{
+		Extra: map[string]any{commands.ReactionCommandsKey: actions},
+	})
+	if evtID == "" {
+		return
+	}
+	pe.sendReactions(ctx, evtID, slices.Collect(maps.Keys(actions))...)
+}

--- a/policyeval/propagate.go
+++ b/policyeval/propagate.go
@@ -90,7 +90,7 @@ func (pe *PolicyEvaluator) propagateUnban(ctx context.Context, unbanEvent *event
 		}
 		n++
 		msg += fmt.Sprintf(
-			"%d. [%s] %s set recommendation %s for %s at %s for %s",
+			"%d. [%s] %s set recommendation %s for %s at %s for %s\n",
 			n,
 			format.EscapeMarkdown(meta.Shortcode),
 			format.MarkdownMention(policy.Sender),
@@ -106,7 +106,10 @@ func (pe *PolicyEvaluator) propagateUnban(ctx context.Context, unbanEvent *event
 	}
 
 	evtID := pe.Bot.SendNoticeOpts(ctx, pe.ManagementRoom, msg, &bot.SendNoticeOpts{
-		Extra: map[string]any{commands.ReactionCommandsKey: actions},
+		Extra: map[string]any{
+			commands.ReactionCommandsKey: actions,
+			commands.ReactionMultiUseKey: true,
+		},
 	})
 	if evtID == "" {
 		return


### PR DESCRIPTION
Sometimes it's faster to ban a problematic user in a room, and then add them to the policy list when you catch a second. This PR makes it easier to do that follow-up step by presenting relevant management rooms with a notice and prompt menu.

If the user was previously not banned, and is now banned, the bot will notify management rooms of who was banned, where, who by, and why, and prompts them to copy that ban to any policy lists that are watched *and* the bot has write access to.

If the user was previously banned, and is now unbanned, the bot will find all matching policies, filter for ones it can remove, provide a similar notification to above, and instead prompts them to remove any of the given policies, provided the bot is capable of removing them (i.e. again, has write access to the relevant list).

https://github.com/user-attachments/assets/5ef002b1-6c79-4dc5-a2aa-815b97d509fc

This is similar in functionality to Draupnir's [BanPropagationProtection](https://the-draupnir-project.github.io/draupnir-documentation/moderator/managing-users#the-banpropagationprotection)