### PR TITLE
Add option to obfuscate banned user profiles

### DIFF
--- a/cmd/meowlnir/main.go
+++ b/cmd/meowlnir/main.go
@@ -280,6 +280,7 @@ func (m *Meowlnir) newPolicyEvaluator(bot *bot.Bot, roomID id.RoomID, encrypted 
 		roomID,
 		encrypted,
 		m.Config.Meowlnir.Untrusted,
+		m.Config.Meowlnir.ObfuscateBans,
 		m4aInit,
 		m.DB,
 		m.SynapseDB,

--- a/config/config.go
+++ b/config/config.go
@@ -43,7 +43,8 @@ type MeowlnirConfig struct {
 	HackyRuleFilter     []string  `yaml:"hacky_rule_filter"`
 	HackyRedactPatterns []string  `yaml:"hacky_redact_patterns"`
 
-	AdminTokens map[id.UserID]string `yaml:"admin_tokens"`
+	AdminTokens   map[id.UserID]string `yaml:"admin_tokens"`
+	ObfuscateBans bool                 `yaml:"obfuscate_bans"`
 }
 
 type Meowlnir4AllConfig struct {

--- a/config/example-config.yaml
+++ b/config/example-config.yaml
@@ -68,6 +68,13 @@ meowlnir:
     admin_tokens:
         "@abuse:example.com": admin_token
 
+    # If true, Meowlnir will override the profile of banned users to make them less identifiable.
+    # This does not work for all clients who may still display the original profile information.
+    # This is ideal if you are dealing with spam where abusive user IDs are in use.
+    #
+    # This will replace the displayname with "Banned User" and the avatar with a generic placeholder.
+    obfuscate_bans: false
+
 # Settings for provisioning new bots using the !provision command.
 # None of this is relevant unless you offer moderation bots to other users.
 meowlnir4all:

--- a/config/upgrade.go
+++ b/config/upgrade.go
@@ -42,6 +42,7 @@ func upgradeConfig(helper up.Helper) {
 	helper.Copy(up.List, "meowlnir", "hacky_rule_filter")
 	helper.Copy(up.List, "meowlnir", "hacky_redact_patterns")
 	helper.Copy(up.Map, "meowlnir", "admin_tokens")
+	helper.Copy(up.Bool, "meowlnir", "obfuscate_bans")
 
 	helper.Copy(up.Str|up.Null, "meowlnir4all", "admin_room")
 	helper.Copy(up.Str, "meowlnir4all", "localpart_template")

--- a/policyeval/execute.go
+++ b/policyeval/execute.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
+	"go.mau.fi/util/random"
 	"maunium.net/go/mautrix"
 	"maunium.net/go/mautrix/commands"
 	"maunium.net/go/mautrix/event"
@@ -188,7 +189,7 @@ func (pe *PolicyEvaluator) ApplyBan(
 		} else {
 			profile := &event.MemberEventContent{
 				Membership:          event.MembershipBan,
-				Displayname:         "Banned User",
+				Displayname:         "Banned User " + random.String(8),
 				AvatarURL:           "mxc://matrix.org/NZGChxcCXbBvgkCNZTLXlpux",
 				MSC4293RedactEvents: shouldRedact,
 			}

--- a/policyeval/execute.go
+++ b/policyeval/execute.go
@@ -178,12 +178,22 @@ func (pe *PolicyEvaluator) ApplyBan(
 	}
 	var err error
 	if !pe.DryRun {
-		_, err = pe.Bot.BanUser(ctx, roomID, &mautrix.ReqBanUser{
-			Reason: filterReason(policy.Reason),
-			UserID: userID,
+		if !pe.ObfuscateBans {
+			_, err = pe.Bot.BanUser(ctx, roomID, &mautrix.ReqBanUser{
+				Reason: filterReason(policy.Reason),
+				UserID: userID,
 
-			MSC4293RedactEvents: shouldRedact,
-		})
+				MSC4293RedactEvents: shouldRedact,
+			})
+		} else {
+			profile := &event.MemberEventContent{
+				Membership:          event.MembershipBan,
+				Displayname:         "Banned User",
+				AvatarURL:           "mxc://matrix.org/NZGChxcCXbBvgkCNZTLXlpux",
+				MSC4293RedactEvents: shouldRedact,
+			}
+			_, err = pe.Bot.SendStateEvent(ctx, roomID, event.StateMember, userID.String(), profile)
+		}
 	}
 	if err != nil {
 		var respErr mautrix.HTTPError

--- a/policyeval/main.go
+++ b/policyeval/main.go
@@ -32,11 +32,12 @@ type protectedRoomMeta struct {
 }
 
 type PolicyEvaluator struct {
-	Bot       *bot.Bot
-	Store     *policylist.Store
-	SynapseDB *synapsedb.SynapseDB
-	DB        *database.Database
-	DryRun    bool
+	Bot           *bot.Bot
+	Store         *policylist.Store
+	SynapseDB     *synapsedb.SynapseDB
+	DB            *database.Database
+	DryRun        bool
+	ObfuscateBans bool
 
 	ManagementRoom    id.RoomID
 	RequireEncryption bool
@@ -86,8 +87,7 @@ func NewPolicyEvaluator(
 	bot *bot.Bot,
 	store *policylist.Store,
 	managementRoom id.RoomID,
-	requireEncryption bool,
-	untrusted bool,
+	requireEncryption, untrusted, obfuscateBans bool,
 	provisionM4A func(context.Context, id.UserID) (id.UserID, id.RoomID, error),
 	db *database.Database,
 	synapseDB *synapsedb.SynapseDB,
@@ -107,6 +107,7 @@ func NewPolicyEvaluator(
 		ManagementRoom:       managementRoom,
 		RequireEncryption:    requireEncryption,
 		Untrusted:            untrusted,
+		ObfuscateBans:        obfuscateBans,
 		provisionM4A:         provisionM4A,
 		Admins:               exsync.NewSet[id.UserID](),
 		commandProcessor:     commands.NewProcessor[*PolicyEvaluator](bot.Client),


### PR DESCRIPTION
Ports over the elided "obfuscate bans" feature from the protections reborn branch. When enabled, all bans will be written to the state directly, overwriting the profile data in the membership, which causes some clients to render a profile defined by the bot (in this case, a generic inoffensive profile).