### PR TITLE
Cache policy check results in memory to avoid overloading the database

### DIFF
--- a/policyeval/policyserver.go
+++ b/policyeval/policyserver.go
@@ -1,6 +1,8 @@
 package policyeval
 
 import (
+	"sync"
+
 	"go.mau.fi/util/exsync"
 	"maunium.net/go/mautrix/federation"
 	"maunium.net/go/mautrix/id"
@@ -14,15 +16,19 @@ type PolicyServer struct {
 	SigningKey     *federation.SigningKey
 	DB             *database.Database
 	redactionCache *exsync.Set[id.EventID]
+	signatureCache map[id.EventID]*database.PSSignature
+	sigCacheMu     sync.RWMutex
 }
 
 func NewPolicyServer(fed *federation.Client, serverAuth *federation.ServerAuth, signingKey *federation.SigningKey, db *database.Database) *PolicyServer {
 	return &PolicyServer{
 		redactionCache: exsync.NewSet[id.EventID](),
+		signatureCache: make(map[id.EventID]*database.PSSignature),
 		Federation:     fed,
 		ServerAuth:     serverAuth,
 		DB:             db,
 		SigningKey:     signingKey,
+		sigCacheMu:     sync.RWMutex{},
 	}
 }
 

--- a/policyeval/policyserver_check.go
+++ b/policyeval/policyserver_check.go
@@ -110,10 +110,17 @@ func (ps *PolicyServer) HandleSign(
 		Stringer("room_id", evt.RoomID).
 		Stringer("event_id", evtID).
 		Logger()
-	sig, err := ps.DB.PSSignature.Get(ctx, evtID)
-	if err != nil {
-		return fmt.Errorf("failed to fetch signature from database: %w", err)
-	} else if sig != nil {
+	ps.sigCacheMu.RLock()
+	sig, ok := ps.signatureCache[evtID]
+	ps.sigCacheMu.RUnlock()
+	if !ok {
+		var err error
+		sig, err = ps.DB.PSSignature.Get(ctx, evtID)
+		if err != nil {
+			return fmt.Errorf("failed to fetch signature from database: %w", err)
+		}
+	}
+	if sig != nil {
 		log.Trace().
 			Time("cached_at", sig.CreatedAt.Time).
 			Str("signature", sig.Signature).
@@ -146,6 +153,9 @@ func (ps *PolicyServer) HandleSign(
 	if !ok {
 		return errors.New("failed to retrieve signature after signing")
 	}
+	ps.sigCacheMu.Lock()
+	ps.signatureCache[evtID] = sig
+	ps.sigCacheMu.Unlock()
 	err = ps.DB.PSSignature.Put(ctx, &database.PSSignature{
 		EventID:   evtID,
 		Signature: newSig,

--- a/policyeval/protections/max_mentions.go
+++ b/policyeval/protections/max_mentions.go
@@ -84,7 +84,7 @@ func (mm *MaxMentions) Execute(ctx context.Context, p policyeval.ProtectionParam
 				zerolog.Ctx(ctx).Err(execErr).Msg("failed to redact message for max_mentions")
 			}
 		}()
-	} else {
+	} else if content.Mentions != nil {
 		for _, uid := range content.Mentions.UserIDs {
 			uniqueMentions[uid] = struct{}{}
 		}


### PR DESCRIPTION
Adds a map to the policy server that caches check results in memory to improve the performance of concurrent lookups. Avoids overloading the database when hundreds of servers are requesting checks/signatures for an event concurrently.