### PR TITLE
config: Move ban obfuscation configuration into protected rooms meta

### DIFF
--- a/cmd/meowlnir/main.go
+++ b/cmd/meowlnir/main.go
@@ -280,7 +280,6 @@ func (m *Meowlnir) newPolicyEvaluator(bot *bot.Bot, roomID id.RoomID, encrypted 
 		roomID,
 		encrypted,
 		m.Config.Meowlnir.Untrusted,
-		m.Config.Meowlnir.ObfuscateBans,
 		m4aInit,
 		m.DB,
 		m.SynapseDB,

--- a/config/config.go
+++ b/config/config.go
@@ -43,8 +43,7 @@ type MeowlnirConfig struct {
 	HackyRuleFilter     []string  `yaml:"hacky_rule_filter"`
 	HackyRedactPatterns []string  `yaml:"hacky_redact_patterns"`
 
-	AdminTokens   map[id.UserID]string `yaml:"admin_tokens"`
-	ObfuscateBans bool                 `yaml:"obfuscate_bans"`
+	AdminTokens map[id.UserID]string `yaml:"admin_tokens"`
 }
 
 type Meowlnir4AllConfig struct {

--- a/config/event.go
+++ b/config/event.go
@@ -36,7 +36,8 @@ type ProtectedRoomsEventContent struct {
 	Protections map[string]json.RawMessage `json:"protections,omitempty"`
 
 	// TODO make this less hacky
-	SkipACL []id.RoomID `json:"skip_acl"`
+	SkipACL       []id.RoomID `json:"skip_acl"`
+	ObfuscateBans bool        `json:"obfuscate_bans,omitempty"`
 }
 
 func init() {

--- a/config/example-config.yaml
+++ b/config/example-config.yaml
@@ -68,13 +68,6 @@ meowlnir:
     admin_tokens:
         "@abuse:example.com": admin_token
 
-    # If true, Meowlnir will override the profile of banned users to make them less identifiable.
-    # This does not work for all clients who may still display the original profile information.
-    # This is ideal if you are dealing with spam where abusive user IDs are in use.
-    #
-    # This will replace the displayname with "Banned User" and the avatar with a generic placeholder.
-    obfuscate_bans: false
-
 # Settings for provisioning new bots using the !provision command.
 # None of this is relevant unless you offer moderation bots to other users.
 meowlnir4all:

--- a/config/upgrade.go
+++ b/config/upgrade.go
@@ -42,7 +42,6 @@ func upgradeConfig(helper up.Helper) {
 	helper.Copy(up.List, "meowlnir", "hacky_rule_filter")
 	helper.Copy(up.List, "meowlnir", "hacky_redact_patterns")
 	helper.Copy(up.Map, "meowlnir", "admin_tokens")
-	helper.Copy(up.Bool, "meowlnir", "obfuscate_bans")
 
 	helper.Copy(up.Str|up.Null, "meowlnir4all", "admin_room")
 	helper.Copy(up.Str, "meowlnir4all", "localpart_template")

--- a/policyeval/execute.go
+++ b/policyeval/execute.go
@@ -179,7 +179,7 @@ func (pe *PolicyEvaluator) ApplyBan(
 	}
 	var err error
 	if !pe.DryRun {
-		if !pe.ObfuscateBans {
+		if !pe.protectedRoomsEvent.ObfuscateBans {
 			_, err = pe.Bot.BanUser(ctx, roomID, &mautrix.ReqBanUser{
 				Reason: filterReason(policy.Reason),
 				UserID: userID,

--- a/policyeval/execute.go
+++ b/policyeval/execute.go
@@ -179,14 +179,10 @@ func (pe *PolicyEvaluator) ApplyBan(
 	}
 	var err error
 	if !pe.DryRun {
-		if !pe.protectedRoomsEvent.ObfuscateBans {
-			_, err = pe.Bot.BanUser(ctx, roomID, &mautrix.ReqBanUser{
-				Reason: filterReason(policy.Reason),
-				UserID: userID,
-
-				MSC4293RedactEvents: shouldRedact,
-			})
-		} else {
+		pe.protectedRoomsLock.RLock()
+		shouldObfuscate := pe.protectedRoomsEvent.ObfuscateBans
+		pe.protectedRoomsLock.RUnlock()
+		if shouldObfuscate {
 			profile := &event.MemberEventContent{
 				Membership:          event.MembershipBan,
 				Displayname:         "Banned User " + random.String(8),
@@ -194,6 +190,13 @@ func (pe *PolicyEvaluator) ApplyBan(
 				MSC4293RedactEvents: shouldRedact,
 			}
 			_, err = pe.Bot.SendStateEvent(ctx, roomID, event.StateMember, userID.String(), profile)
+		} else {
+			_, err = pe.Bot.BanUser(ctx, roomID, &mautrix.ReqBanUser{
+				Reason: filterReason(policy.Reason),
+				UserID: userID,
+
+				MSC4293RedactEvents: shouldRedact,
+			})
 		}
 	}
 	if err != nil {

--- a/policyeval/main.go
+++ b/policyeval/main.go
@@ -32,12 +32,11 @@ type protectedRoomMeta struct {
 }
 
 type PolicyEvaluator struct {
-	Bot           *bot.Bot
-	Store         *policylist.Store
-	SynapseDB     *synapsedb.SynapseDB
-	DB            *database.Database
-	DryRun        bool
-	ObfuscateBans bool
+	Bot       *bot.Bot
+	Store     *policylist.Store
+	SynapseDB *synapsedb.SynapseDB
+	DB        *database.Database
+	DryRun    bool
 
 	ManagementRoom    id.RoomID
 	RequireEncryption bool
@@ -87,7 +86,7 @@ func NewPolicyEvaluator(
 	bot *bot.Bot,
 	store *policylist.Store,
 	managementRoom id.RoomID,
-	requireEncryption, untrusted, obfuscateBans bool,
+	requireEncryption, untrusted bool,
 	provisionM4A func(context.Context, id.UserID) (id.UserID, id.RoomID, error),
 	db *database.Database,
 	synapseDB *synapsedb.SynapseDB,
@@ -107,7 +106,6 @@ func NewPolicyEvaluator(
 		ManagementRoom:       managementRoom,
 		RequireEncryption:    requireEncryption,
 		Untrusted:            untrusted,
-		ObfuscateBans:        obfuscateBans,
 		provisionM4A:         provisionM4A,
 		Admins:               exsync.NewSet[id.UserID](),
 		commandProcessor:     commands.NewProcessor[*PolicyEvaluator](bot.Client),


### PR DESCRIPTION
Builds on the changes made in #57 by moving the `obfuscate_bans` configuration into the `fi.mau.meowlnir.protected_rooms` event, allowing moderators utilising Meowlnir4All (like asgard.chat) to take advantage of ban obfuscation without being the instance operator.