### PR TITLE
policyeval: Prevent soft-deadlock during evaluator startup

### DIFF
--- a/cmd/meowlnir/main.go
+++ b/cmd/meowlnir/main.go
@@ -74,7 +74,6 @@ type Meowlnir struct {
 	HackyAutoRedactPatterns   []glob.Glob
 
 	appservicePingOnce sync.Once
-	startupComplete    chan struct{}
 
 	RoomHashes *roomhash.Map
 }
@@ -140,7 +139,6 @@ func (m *Meowlnir) Init(configPath string, noSaveConfig bool) {
 		}
 	}
 
-	m.startupComplete = make(chan struct{})
 	m.RoomHashes = roomhash.NewMap()
 	m.DB = database.New(mainDB)
 	m.StateStore = sqlstatestore.NewSQLStateStore(mainDB, dbutil.ZeroLogger(m.Log.With().Str("db_section", "matrix_state").Logger()), false)
@@ -386,7 +384,6 @@ func (m *Meowlnir) Run(ctx context.Context) {
 
 	m.Log.Info().Msg("Startup complete")
 	m.AS.Ready = true
-	close(m.startupComplete)
 
 	<-ctx.Done()
 	err = m.DB.Close()

--- a/cmd/meowlnir/policyserver.go
+++ b/cmd/meowlnir/policyserver.go
@@ -52,7 +52,6 @@ func (m *Meowlnir) PostMSC4284LegacyEventCheck(w http.ResponseWriter, r *http.Re
 		mautrix.MNotJSON.WithMessage("Request body is not valid JSON").Write(w)
 		return
 	}
-	<-m.startupComplete
 	var ok bool
 	m.MapLock.RLock()
 	eval, ok := m.EvaluatorByProtectedRoom[parsedPDU.RoomID]
@@ -117,7 +116,6 @@ func (m *Meowlnir) postPolicyServerSign(w http.ResponseWriter, r *http.Request, 
 		mautrix.MNotJSON.WithMessage("Request body is not valid JSON").Write(w)
 		return
 	}
-	<-m.startupComplete
 	var ok bool
 	m.MapLock.RLock()
 	eval, ok := m.EvaluatorByProtectedRoom[parsedPDU.RoomID]

--- a/policyeval/main.go
+++ b/policyeval/main.go
@@ -58,7 +58,8 @@ type PolicyEvaluator struct {
 	configLock sync.Mutex
 	aclLock    sync.Mutex
 
-	aclDeferChan chan struct{}
+	aclDeferChan    chan struct{}
+	startupFinished chan struct{}
 
 	claimProtected       func(roomID id.RoomID, eval *PolicyEvaluator, claim bool) *PolicyEvaluator
 	protectedRoomsEvent  *config.ProtectedRoomsEventContent
@@ -117,6 +118,7 @@ func NewPolicyEvaluator(
 		wantToProtect:        make(map[id.RoomID]struct{}),
 		isJoining:            make(map[id.RoomID]struct{}),
 		aclDeferChan:         make(chan struct{}, 1),
+		startupFinished:      make(chan struct{}),
 		claimProtected:       claimProtected,
 		pendingInvites:       make(map[pendingInvite]struct{}),
 		createPuppetClient:   createPuppetClient,
@@ -234,38 +236,37 @@ func (pe *PolicyEvaluator) tryLoad(ctx context.Context) error {
 		_, errorMsgs := pe.handleProtectedRooms(ctx, evt, true)
 		errors = append(errors, errorMsgs...)
 	}
+	close(pe.startupFinished)
 	initDuration := time.Since(start)
-	go func() {
-		start = time.Now()
-		pe.EvaluateAll(ctx)
-		evalDuration := time.Since(start)
-		pe.protectedRoomsLock.Lock()
-		userCount := len(pe.protectedRoomMembers)
-		var joinedUserCount int
-		for _, rooms := range pe.protectedRoomMembers {
-			if len(rooms) > 0 {
-				joinedUserCount++
-			}
+	start = time.Now()
+	pe.EvaluateAll(ctx)
+	evalDuration := time.Since(start)
+	pe.protectedRoomsLock.Lock()
+	userCount := len(pe.protectedRoomMembers)
+	var joinedUserCount int
+	for _, rooms := range pe.protectedRoomMembers {
+		if len(rooms) > 0 {
+			joinedUserCount++
 		}
-		protectedRoomsCount := len(pe.protectedRooms)
-		pe.protectedRoomsLock.Unlock()
-		var msg string
-		if len(errors) > 0 {
-			msg = fmt.Sprintf("Errors occurred during initialization:\n\n%s\n\nProtecting %d rooms with %d users (%d all time) using %d lists.",
-				strings.Join(errors, "\n"), protectedRoomsCount, joinedUserCount, userCount, len(pe.GetWatchedLists()))
-		} else {
-			msg = fmt.Sprintf("Initialization completed successfully (took %s to load data and %s to evaluate rules). "+
-				"Protecting %d rooms with %d users (%d all time) using %d lists.",
-				initDuration, evalDuration, protectedRoomsCount, joinedUserCount, userCount, len(pe.GetWatchedLists()))
-		}
-		if pe.DryRun {
-			msg += "\n\n**Dry run mode is enabled, no actions will be taken.**"
-		}
-		pe.sendNotice(ctx, msg)
-		if pls.GetUserLevel(pe.Bot.UserID) >= pls.GetEventLevel(event.StateMSC4391BotCommand) {
-			pe.syncCommandDescriptions(ctx, state[event.StateMSC4391BotCommand])
-		}
-	}()
+	}
+	protectedRoomsCount := len(pe.protectedRooms)
+	pe.protectedRoomsLock.Unlock()
+	var msg string
+	if len(errors) > 0 {
+		msg = fmt.Sprintf("Errors occurred during initialization:\n\n%s\n\nProtecting %d rooms with %d users (%d all time) using %d lists.",
+			strings.Join(errors, "\n"), protectedRoomsCount, joinedUserCount, userCount, len(pe.GetWatchedLists()))
+	} else {
+		msg = fmt.Sprintf("Initialization completed successfully (took %s to load data and %s to evaluate rules). "+
+			"Protecting %d rooms with %d users (%d all time) using %d lists.",
+			initDuration, evalDuration, protectedRoomsCount, joinedUserCount, userCount, len(pe.GetWatchedLists()))
+	}
+	if pe.DryRun {
+		msg += "\n\n**Dry run mode is enabled, no actions will be taken.**"
+	}
+	pe.sendNotice(ctx, msg)
+	if pls.GetUserLevel(pe.Bot.UserID) >= pls.GetEventLevel(event.StateMSC4391BotCommand) {
+		pe.syncCommandDescriptions(ctx, state[event.StateMSC4391BotCommand])
+	}
 	return nil
 }
 

--- a/policyeval/main.go
+++ b/policyeval/main.go
@@ -58,8 +58,9 @@ type PolicyEvaluator struct {
 	configLock sync.Mutex
 	aclLock    sync.Mutex
 
-	aclDeferChan    chan struct{}
-	startupFinished chan struct{}
+	aclDeferChan        chan struct{}
+	finishedLoadingChan chan struct{}
+	finishLoading       func()
 
 	claimProtected       func(roomID id.RoomID, eval *PolicyEvaluator, claim bool) *PolicyEvaluator
 	protectedRoomsEvent  *config.ProtectedRoomsEventContent
@@ -118,7 +119,7 @@ func NewPolicyEvaluator(
 		wantToProtect:        make(map[id.RoomID]struct{}),
 		isJoining:            make(map[id.RoomID]struct{}),
 		aclDeferChan:         make(chan struct{}, 1),
-		startupFinished:      make(chan struct{}),
+		finishedLoadingChan:  make(chan struct{}),
 		claimProtected:       claimProtected,
 		pendingInvites:       make(map[pendingInvite]struct{}),
 		createPuppetClient:   createPuppetClient,
@@ -132,6 +133,9 @@ func NewPolicyEvaluator(
 		policyServer:         policyServer,
 		RoomHashes:           roomHashes,
 	}
+	pe.finishLoading = sync.OnceFunc(func() {
+		close(pe.finishedLoadingChan)
+	})
 	pe.commandProcessor.LogArgs = true
 	pe.commandProcessor.Meta = pe
 	pe.commandProcessor.PreValidator = commands.AnyPreValidator[*PolicyEvaluator]{
@@ -236,7 +240,7 @@ func (pe *PolicyEvaluator) tryLoad(ctx context.Context) error {
 		_, errorMsgs := pe.handleProtectedRooms(ctx, evt, true)
 		errors = append(errors, errorMsgs...)
 	}
-	close(pe.startupFinished)
+	pe.finishLoading()
 	initDuration := time.Since(start)
 	start = time.Now()
 	pe.EvaluateAll(ctx)

--- a/policyeval/main.go
+++ b/policyeval/main.go
@@ -235,35 +235,37 @@ func (pe *PolicyEvaluator) tryLoad(ctx context.Context) error {
 		errors = append(errors, errorMsgs...)
 	}
 	initDuration := time.Since(start)
-	start = time.Now()
-	pe.EvaluateAll(ctx)
-	evalDuration := time.Since(start)
-	pe.protectedRoomsLock.Lock()
-	userCount := len(pe.protectedRoomMembers)
-	var joinedUserCount int
-	for _, rooms := range pe.protectedRoomMembers {
-		if len(rooms) > 0 {
-			joinedUserCount++
+	go func() {
+		start = time.Now()
+		pe.EvaluateAll(ctx)
+		evalDuration := time.Since(start)
+		pe.protectedRoomsLock.Lock()
+		userCount := len(pe.protectedRoomMembers)
+		var joinedUserCount int
+		for _, rooms := range pe.protectedRoomMembers {
+			if len(rooms) > 0 {
+				joinedUserCount++
+			}
 		}
-	}
-	protectedRoomsCount := len(pe.protectedRooms)
-	pe.protectedRoomsLock.Unlock()
-	var msg string
-	if len(errors) > 0 {
-		msg = fmt.Sprintf("Errors occurred during initialization:\n\n%s\n\nProtecting %d rooms with %d users (%d all time) using %d lists.",
-			strings.Join(errors, "\n"), protectedRoomsCount, joinedUserCount, userCount, len(pe.GetWatchedLists()))
-	} else {
-		msg = fmt.Sprintf("Initialization completed successfully (took %s to load data and %s to evaluate rules). "+
-			"Protecting %d rooms with %d users (%d all time) using %d lists.",
-			initDuration, evalDuration, protectedRoomsCount, joinedUserCount, userCount, len(pe.GetWatchedLists()))
-	}
-	if pe.DryRun {
-		msg += "\n\n**Dry run mode is enabled, no actions will be taken.**"
-	}
-	pe.sendNotice(ctx, msg)
-	if pls.GetUserLevel(pe.Bot.UserID) >= pls.GetEventLevel(event.StateMSC4391BotCommand) {
-		pe.syncCommandDescriptions(ctx, state[event.StateMSC4391BotCommand])
-	}
+		protectedRoomsCount := len(pe.protectedRooms)
+		pe.protectedRoomsLock.Unlock()
+		var msg string
+		if len(errors) > 0 {
+			msg = fmt.Sprintf("Errors occurred during initialization:\n\n%s\n\nProtecting %d rooms with %d users (%d all time) using %d lists.",
+				strings.Join(errors, "\n"), protectedRoomsCount, joinedUserCount, userCount, len(pe.GetWatchedLists()))
+		} else {
+			msg = fmt.Sprintf("Initialization completed successfully (took %s to load data and %s to evaluate rules). "+
+				"Protecting %d rooms with %d users (%d all time) using %d lists.",
+				initDuration, evalDuration, protectedRoomsCount, joinedUserCount, userCount, len(pe.GetWatchedLists()))
+		}
+		if pe.DryRun {
+			msg += "\n\n**Dry run mode is enabled, no actions will be taken.**"
+		}
+		pe.sendNotice(ctx, msg)
+		if pls.GetUserLevel(pe.Bot.UserID) >= pls.GetEventLevel(event.StateMSC4391BotCommand) {
+			pe.syncCommandDescriptions(ctx, state[event.StateMSC4391BotCommand])
+		}
+	}()
 	return nil
 }
 

--- a/policyeval/policyserver_check.go
+++ b/policyeval/policyserver_check.go
@@ -33,6 +33,7 @@ func (ps *PolicyServer) getRecommendation(
 	if pdu.Sender == evaluator.Bot.UserID || evaluator.Admins.Has(pdu.Sender) {
 		return "admin", nil
 	}
+	<-evaluator.startupFinished
 	watchedLists := evaluator.GetWatchedLists()
 	match := evaluator.Store.MatchUser(watchedLists, pdu.Sender)
 	if match != nil {

--- a/policyeval/policyserver_check.go
+++ b/policyeval/policyserver_check.go
@@ -33,7 +33,7 @@ func (ps *PolicyServer) getRecommendation(
 	if pdu.Sender == evaluator.Bot.UserID || evaluator.Admins.Has(pdu.Sender) {
 		return "admin", nil
 	}
-	<-evaluator.startupFinished
+	<-evaluator.finishedLoadingChan
 	watchedLists := evaluator.GetWatchedLists()
 	match := evaluator.Store.MatchUser(watchedLists, pdu.Sender)
 	if match != nil {


### PR DESCRIPTION
Fixes #64 by making the startup channel per-evaluator rather than global, allowing evaluators to signal when they've finished loading policies (at which point policy server checks can be performed, and the startup state eval can also execute).

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
