### PR TITLE
policyeval/commands: capture multi-word reasons in !add-unban

### DIFF
--- a/policyeval/commands.go
+++ b/policyeval/commands.go
@@ -696,6 +696,7 @@ var cmdAddUnban = &CommandHandler{
 	Name:        "add-unban",
 	Description: event.MakeExtensibleText("Add an unban policy to a policy list"),
 	Parameters:  cmdBan.Parameters[:3],
+	TailParam:   "reason",
 	Func: commands.WithParsedArgs(func(ce *CommandEvent, args *BanParams) {
 		list := ce.Meta.FindListByShortcode(args.List)
 		if list == nil {


### PR DESCRIPTION
cmdAddUnban borrows cmdBan's parameters, but not its TailParam,
so a reason spanning multiple words was not stored correctly.
All other reason-taking commands (`!ban`, `!kick`, `!redact`, `!redact-recent`)
already declare the tail parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)