### PR TITLE
database: Fix v4 migration for unencrypted meowlnirs

### DIFF
--- a/database/upgrades/04-repair-otks.go
+++ b/database/upgrades/04-repair-otks.go
@@ -1,0 +1,33 @@
+package upgrades
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"go.mau.fi/util/dbutil"
+)
+
+var V04 = dbutil.WrapUpgrade(3, 4, 1, "Mark OTKs as needing repair", dbutil.TxnModeOn, func(ctx context.Context, database *dbutil.Database) error {
+	var cryptoTableExists bool
+	var err error
+	if database.Dialect == dbutil.Postgres {
+		err = database.QueryRow(ctx, "SELECT true FROM information_schema.tables WHERE table_schema = current_schema() AND table_name = 'crypto_account'").Scan(&cryptoTableExists)
+
+	} else {
+		err = database.QueryRow(ctx, "SELECT true FROM sqlite_master WHERE type = 'table' AND name = 'crypto_account'").Scan(&cryptoTableExists)
+	}
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return fmt.Errorf("failed to presence check crypto account table: %w", err)
+	}
+	_, err = database.Exec(ctx, "CREATE TABLE otks_need_reset(user_id TEXT PRIMARY KEY)")
+	if err != nil {
+		return err
+	}
+	if !cryptoTableExists {
+		return nil
+	}
+	_, err = database.Exec(ctx, "INSERT INTO otks_need_reset SELECT DISTINCT account_id FROM crypto_account WHERE shared=TRUE")
+	return err
+})

--- a/database/upgrades/04-repair-otks.sql
+++ b/database/upgrades/04-repair-otks.sql
@@ -1,3 +1,0 @@
--- v4 (compatible with v1+): Mark OTKs as needing repair
-CREATE TABLE otks_need_reset(user_id TEXT PRIMARY KEY);
-INSERT INTO otks_need_reset SELECT DISTINCT account_id FROM crypto_account WHERE shared=TRUE;

--- a/database/upgrades/upgrades.go
+++ b/database/upgrades/upgrades.go
@@ -6,7 +6,7 @@ import (
 	"go.mau.fi/util/dbutil"
 )
 
-var Table = dbutil.BuildUpgradeTable().WithFS(rawUpgrades).Finish()
+var Table = dbutil.BuildUpgradeTable().WithFS(rawUpgrades).With(V04).Finish()
 
 //go:embed *.sql
 var rawUpgrades embed.FS


### PR DESCRIPTION
Checks for the existence of the crypto_accounts table before trying to select from it (which broke unencrypted Meowlnir deployments)

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
