### PR TITLE
policyeval/commands: Automatically offer to protect space children

### DIFF
--- a/policyeval/commands.go
+++ b/policyeval/commands.go
@@ -1397,11 +1397,13 @@ var cmdProtectRoom = &CommandHandler{
 						return
 					}
 					if createContent.Type != event.RoomTypeSpace {
+						ce.Log.Trace().Stringer("room_id", roomID).Msg("Room is not a space, not discovering children")
 						return
 					}
 					// Using hierarchy also includes things like room names, making display easier.
 					// It might not reveal everything inspecting the state would, but good enough
 					// as a convenience.
+					ce.Log.Debug().Stringer("space_room_id", roomID).Msg("Discovering room children")
 					hierarchy, err := ce.Meta.Bot.Hierarchy(ctx, roomID, &mautrix.ReqHierarchy{Limit: 50, MaxDepth: new(1)})
 					if err != nil {
 						ce.Log.Err(err).Msg("Failed to get protected space's hierachy while discovering children")
@@ -1411,10 +1413,15 @@ var cmdProtectRoom = &CommandHandler{
 					for _, child := range hierarchy.Rooms {
 						if slices.Contains(contentCopy.Rooms, child.RoomID) {
 							ce.Log.Trace().
+								Stringer("space_room_id", child.RoomID).
 								Stringer("room_id", child.RoomID).
 								Msg("Discovered child of space that is already protected")
 							continue
 						}
+						ce.Log.Trace().
+							Stringer("space_room_id", roomID).
+							Stringer("child_room_id", child.RoomID).
+							Msg("Discovered unprotected child")
 						discoveredChildren = append(discoveredChildren, child)
 					}
 					if len(discoveredChildren) == 0 {
@@ -1429,17 +1436,19 @@ var cmdProtectRoom = &CommandHandler{
 					keys := make(map[string]string, len(discoveredChildren))
 					for idx, child := range discoveredChildren {
 						content.WriteString(fmt.Sprintf(
-							"%d. %s",
+							"%d. %s\n",
 							idx, format.MarkdownMentionRoomID(child.Name, child.RoomID, ce.Sender.Homeserver())))
 						target := cmp.Or(child.CanonicalAlias.String(), child.RoomID.URI(ce.Sender.Homeserver()).String())
 						key := cmp.Or(child.Name, child.CanonicalAlias.String(), child.RoomID.String())
-						keys[key] = "/protect --join " + target
+						keys["/"+key] = "!protect --join " + target
 					}
-					ce.Meta.Bot.SendNoticeOpts(ctx, roomID, content.String(), &bot.SendNoticeOpts{
+					menuID := ce.Meta.Bot.SendNoticeOpts(ctx, ce.RoomID, content.String(), &bot.SendNoticeOpts{
 						Extra: map[string]any{
 							commands.ReactionCommandsKey: keys,
+							commands.ReactionMultiUseKey: true,
 						},
 					})
+					ce.Meta.sendReactions(ctx, menuID, slices.Collect(maps.Keys(keys))...)
 				}()
 			} else {
 				if itemIdx < 0 {

--- a/policyeval/commands.go
+++ b/policyeval/commands.go
@@ -1,6 +1,7 @@
 package policyeval
 
 import (
+	"cmp"
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
@@ -25,6 +26,8 @@ import (
 	"maunium.net/go/mautrix/format"
 	"maunium.net/go/mautrix/id"
 	"maunium.net/go/mautrix/synapseadmin"
+
+	"go.mau.fi/meowlnir/bot"
 
 	"go.mau.fi/meowlnir/config"
 	"go.mau.fi/meowlnir/policylist"
@@ -1369,6 +1372,59 @@ var cmdProtectRoom = &CommandHandler{
 				}
 				contentCopy.Rooms = append(contentCopy.Rooms, roomID)
 				changed = true
+				go func() {
+					ctx := context.WithoutCancel(ce.Ctx)
+					var createContent event.CreateEventContent
+					err := ce.Meta.Bot.StateEvent(ctx, roomID, event.StateCreate, "", &createContent)
+					if err != nil {
+						ce.Log.Err(err).Msg("Failed to get protected room's create event")
+						return
+					}
+					if createContent.Type != event.RoomTypeSpace {
+						return
+					}
+					// Using hierarchy also includes things like room names, making display easier.
+					// It might not reveal everything inspecting the state would, but good enough
+					// as a convenience.
+					hierarchy, err := ce.Meta.Bot.Hierarchy(ctx, roomID, &mautrix.ReqHierarchy{Limit: 50, MaxDepth: new(1)})
+					if err != nil {
+						ce.Log.Err(err).Msg("Failed to get protected space's hierachy while discovering children")
+						return
+					}
+					discoveredChildren := make([]*mautrix.ChildRoomsChunk, 0, len(hierarchy.Rooms))
+					for _, child := range hierarchy.Rooms {
+						if slices.Contains(contentCopy.Rooms, child.RoomID) {
+							ce.Log.Trace().
+								Stringer("room_id", child.RoomID).
+								Msg("Discovered child of space that is already protected")
+							continue
+						}
+						discoveredChildren = append(discoveredChildren, child)
+					}
+					if len(discoveredChildren) == 0 {
+						ce.Log.Debug().Msg("Space revealed no unprotected children")
+						return
+					}
+					var content strings.Builder
+					content.WriteString(fmt.Sprintf(
+						"Which children of the space %s would you like to protect?\n\n",
+						format.MarkdownMentionRoomID("", roomID, ce.Sender.Homeserver()),
+					))
+					keys := make(map[string]string, len(discoveredChildren))
+					for idx, child := range discoveredChildren {
+						content.WriteString(fmt.Sprintf(
+							"%d. %s",
+							idx, format.MarkdownMentionRoomID(child.Name, child.RoomID, ce.Sender.Homeserver())))
+						target := cmp.Or(child.CanonicalAlias.String(), child.RoomID.URI(ce.Sender.Homeserver()).String())
+						key := cmp.Or(child.Name, child.CanonicalAlias.String(), child.RoomID.String())
+						keys[key] = "/protect " + target
+					}
+					ce.Meta.Bot.SendNoticeOpts(ctx, roomID, content.String(), &bot.SendNoticeOpts{
+						Extra: map[string]any{
+							commands.ReactionCommandsKey: keys,
+						},
+					})
+				}()
 			} else {
 				if itemIdx < 0 {
 					ce.Reply("%s is not protected", format.SafeMarkdownCode(roomID))

--- a/policyeval/commands.go
+++ b/policyeval/commands.go
@@ -1334,6 +1334,7 @@ var cmdProvision = &CommandHandler{
 }
 
 type ProtectRoomParams struct {
+	Join  bool                       `json:"join"`
 	Rooms []cmdschema.RoomIDOrString `json:"room"`
 }
 
@@ -1346,6 +1347,10 @@ var cmdProtectRoom = &CommandHandler{
 	Name:        "protect",
 	Description: event.MakeExtensibleText("Add rooms to the protected rooms list"),
 	Parameters: []*cmdschema.Parameter{{
+		Key:      "join",
+		Schema:   cmdschema.PrimitiveTypeBoolean.Schema(),
+		Optional: true,
+	}, {
 		Key:    "room",
 		Schema: cmdschema.Array(cmdschema.ParameterSchemaJoinableRoom),
 	}},
@@ -1369,6 +1374,17 @@ var cmdProtectRoom = &CommandHandler{
 				if itemIdx >= 0 {
 					ce.Reply("%s is already protected", format.SafeMarkdownCode(roomID))
 					continue
+				}
+				if args.Join {
+					_, err := ce.Meta.Bot.JoinRoom(
+						ce.Ctx,
+						string(room),
+						&mautrix.ReqJoinRoom{Via: []string{ce.Sender.Homeserver()}},
+					)
+					if err != nil {
+						ce.Reply("Failed to join %s (%v), skipping (try inviting me)", format.SafeMarkdownCode(roomID), err)
+						continue
+					}
 				}
 				contentCopy.Rooms = append(contentCopy.Rooms, roomID)
 				changed = true
@@ -1417,7 +1433,7 @@ var cmdProtectRoom = &CommandHandler{
 							idx, format.MarkdownMentionRoomID(child.Name, child.RoomID, ce.Sender.Homeserver())))
 						target := cmp.Or(child.CanonicalAlias.String(), child.RoomID.URI(ce.Sender.Homeserver()).String())
 						key := cmp.Or(child.Name, child.CanonicalAlias.String(), child.RoomID.String())
-						keys[key] = "/protect " + target
+						keys[key] = "/protect --join " + target
 					}
 					ce.Meta.Bot.SendNoticeOpts(ctx, roomID, content.String(), &bot.SendNoticeOpts{
 						Extra: map[string]any{


### PR DESCRIPTION
Closes #30 

When a space is discovered via `!protect`, the hierarchy will be inspected to list up to 100 unprotected rooms. The bot will then offer to protect those rooms through the reaction menu.

This implicitly allows "spidering" a space, as when a subspace is protected through these buttons, it will trigger the same child protection menu.

The other option I considered while designing this was a `--recursive` flag, which would make Meowlnir walk the hierarchy entirely and automatically protect any room it could join and had power level in, however I figured that might be too naive of an algorithm and explicit is better.

Either way, this solves the issue I had where each of our rooms had to be manually protected after upgrading every single room and space in the community. It might be a bit hacky but :woman_shrugging:

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
