### PR TITLE
policyserver: Add block notifications

### DIFF
--- a/config/event.go
+++ b/config/event.go
@@ -36,8 +36,9 @@ type ProtectedRoomsEventContent struct {
 	Protections map[string]json.RawMessage `json:"protections,omitempty"`
 
 	// TODO make this less hacky
-	SkipACL       []id.RoomID `json:"skip_acl"`
-	ObfuscateBans bool        `json:"obfuscate_bans,omitempty"`
+	SkipACL                      []id.RoomID `json:"skip_acl"`
+	ObfuscateBans                bool        `json:"obfuscate_bans,omitempty"`
+	PolicyServerNotificationRoom id.RoomID   `json:"policy_server_notification_room,omitempty"`
 }
 
 func init() {

--- a/policyeval/policyserver_check.go
+++ b/policyeval/policyserver_check.go
@@ -13,7 +13,6 @@ import (
 	"github.com/rs/zerolog"
 	"go.mau.fi/util/exerrors"
 	"go.mau.fi/util/jsontime"
-	"maunium.net/go/mautrix/crypto/canonicaljson"
 	"maunium.net/go/mautrix/event"
 	"maunium.net/go/mautrix/federation/pdu"
 	"maunium.net/go/mautrix/format"
@@ -142,7 +141,7 @@ func (ps *PolicyServer) sendNotification(ctx context.Context, eval *PolicyEvalua
 	if err != nil {
 		marshalled = fmt.Appendf([]byte{}, "\"non JSON object: %v\"", err)
 	} else if len(marshalled) > 30000 {
-		marshalled = exerrors.Must(canonicaljson.Marshal(evt))
+		marshalled = exerrors.Must(json.Marshal(evt))
 	}
 	if len(marshalled) > 30000 {
 		marshalled = fmt.Appendf(

--- a/policyeval/policyserver_check.go
+++ b/policyeval/policyserver_check.go
@@ -11,7 +11,9 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
+	"go.mau.fi/util/exerrors"
 	"go.mau.fi/util/jsontime"
+	"maunium.net/go/mautrix/crypto/canonicaljson"
 	"maunium.net/go/mautrix/event"
 	"maunium.net/go/mautrix/federation/pdu"
 	"maunium.net/go/mautrix/format"
@@ -139,6 +141,16 @@ func (ps *PolicyServer) sendNotification(ctx context.Context, eval *PolicyEvalua
 	marshalled, err := json.Marshal(evt, jsontext.WithIndent("  "))
 	if err != nil {
 		marshalled = fmt.Appendf([]byte{}, "\"non JSON object: %v\"", err)
+	} else if len(marshalled) > 30000 {
+		marshalled = exerrors.Must(canonicaljson.Marshal(evt))
+	}
+	if len(marshalled) > 30000 {
+		marshalled = fmt.Appendf(
+			[]byte{},
+			"%s[%.2f KiB trimmed]",
+			marshalled[:30000],
+			float64(len(marshalled)-30000)/1024.0,
+		)
 	}
 	var errMsg string
 	if rec.Error != nil {

--- a/policyeval/policyserver_check.go
+++ b/policyeval/policyserver_check.go
@@ -170,7 +170,19 @@ func (ps *PolicyServer) sendNotification(ctx context.Context, eval *PolicyEvalua
 		ctx,
 		notifyRoom,
 		content,
-		&bot.SendNoticeOpts{AllowHTML: true},
+		&bot.SendNoticeOpts{
+			AllowHTML: true,
+			Extra: map[string]any{
+				"fi.mau.meowlnir.notification_metadata": map[string]any{
+					"room_id":          evt.RoomID,
+					"sender":           evt.Sender,
+					"event_type":       evt.Type,
+					"state_key":        evt.StateKey,
+					"origin_server_ts": evt.OriginServerTS,
+					"recommendation":   rec,
+				},
+			},
+		},
 	)
 }
 

--- a/policyeval/policyserver_check.go
+++ b/policyeval/policyserver_check.go
@@ -131,7 +131,7 @@ func (ps *PolicyServer) sendNotification(ctx context.Context, eval *PolicyEvalua
 		return
 	}
 	notifyRoom := eval.protectedRoomsEvent.PolicyServerNotificationRoom
-	if notifyRoom == "" || eval.Untrusted && !eval.IsProtectedRoom(notifyRoom) {
+	if notifyRoom == "" || (eval.Untrusted && !eval.canReceiveNotifications(notifyRoom)) {
 		return
 	}
 	srcMeta := eval.getProtectedRoomMeta(evt.RoomID)

--- a/policyeval/policyserver_check.go
+++ b/policyeval/policyserver_check.go
@@ -17,6 +17,8 @@ import (
 	"maunium.net/go/mautrix/format"
 	"maunium.net/go/mautrix/id"
 
+	"go.mau.fi/meowlnir/bot"
+
 	"go.mau.fi/meowlnir/database"
 	"go.mau.fi/meowlnir/policylist"
 )
@@ -144,15 +146,19 @@ func (ps *PolicyServer) sendNotification(ctx context.Context, eval *PolicyEvalua
 	} else {
 		errMsg = rec.DisplayError
 	}
-	eval.Bot.SendNotice(
-		ctx,
-		notifyRoom,
+	content := fmt.Sprintf(
 		"Event %s by %s blocked in %s: %s\n<details><summary>Event JSON</summary>\n\n```json\n%s\n```\n</details>",
 		format.SafeMarkdownCode(evt.Type),
 		format.MarkdownMention(evt.Sender),
 		format.MarkdownMentionRoomID(roomName.Name, evt.RoomID, ps.Federation.ServerName),
 		errMsg,
 		string(marshalled),
+	)
+	eval.Bot.SendNoticeOpts(
+		ctx,
+		notifyRoom,
+		content,
+		&bot.SendNoticeOpts{AllowHTML: true},
 	)
 }
 

--- a/policyeval/policyserver_check.go
+++ b/policyeval/policyserver_check.go
@@ -164,7 +164,7 @@ func (ps *PolicyServer) sendNotification(ctx context.Context, eval *PolicyEvalua
 		format.MarkdownMention(evt.Sender),
 		format.MarkdownMentionRoomID(roomName.Name, evt.RoomID, ps.Federation.ServerName),
 		errMsg,
-		string(marshalled),
+		marshalled,
 	)
 	eval.Bot.SendNoticeOpts(
 		ctx,

--- a/policyeval/policyserver_check.go
+++ b/policyeval/policyserver_check.go
@@ -134,8 +134,7 @@ func (ps *PolicyServer) sendNotification(ctx context.Context, eval *PolicyEvalua
 	if notifyRoom == "" || eval.Untrusted && !eval.IsProtectedRoom(notifyRoom) {
 		return
 	}
-	var roomName event.RoomNameEventContent
-	_ = eval.Bot.StateEvent(ctx, evt.RoomID, event.StateRoomName, "", &roomName)
+	srcMeta := eval.getProtectedRoomMeta(evt.RoomID)
 
 	marshalled, err := json.Marshal(evt, jsontext.WithIndent("  "))
 	if err != nil {
@@ -161,7 +160,7 @@ func (ps *PolicyServer) sendNotification(ctx context.Context, eval *PolicyEvalua
 		"Event %s by %s blocked in %s: %s\n<details><summary>Event JSON</summary>\n\n```json\n%s\n```\n</details>",
 		format.SafeMarkdownCode(evt.Type),
 		format.MarkdownMention(evt.Sender),
-		format.MarkdownMentionRoomID(roomName.Name, evt.RoomID, ps.Federation.ServerName),
+		format.MarkdownMentionRoomID(srcMeta.Name, evt.RoomID, ps.Federation.ServerName),
 		errMsg,
 		marshalled,
 	)

--- a/policyeval/policyserver_check.go
+++ b/policyeval/policyserver_check.go
@@ -131,7 +131,7 @@ func (ps *PolicyServer) sendNotification(ctx context.Context, eval *PolicyEvalua
 		return
 	}
 	notifyRoom := eval.protectedRoomsEvent.PolicyServerNotificationRoom
-	if notifyRoom == "" {
+	if notifyRoom == "" || eval.Untrusted && !eval.IsProtectedRoom(notifyRoom) {
 		return
 	}
 	var roomName event.RoomNameEventContent

--- a/policyeval/policyserver_check.go
+++ b/policyeval/policyserver_check.go
@@ -4,6 +4,8 @@ package policyeval
 
 import (
 	"context"
+	"encoding/json/jsontext"
+	"encoding/json/v2"
 	"errors"
 	"fmt"
 	"time"
@@ -12,6 +14,7 @@ import (
 	"go.mau.fi/util/jsontime"
 	"maunium.net/go/mautrix/event"
 	"maunium.net/go/mautrix/federation/pdu"
+	"maunium.net/go/mautrix/format"
 	"maunium.net/go/mautrix/id"
 
 	"go.mau.fi/meowlnir/database"
@@ -30,11 +33,16 @@ func (ps *PolicyServer) getRecommendation(
 	roomVersion id.RoomVersion,
 	evaluator *PolicyEvaluator,
 	isOrigin, isLegacyCheck bool,
-) (string, *BlockRecommendation, error) {
+) (allowReason string, rec *BlockRecommendation, err error) {
+	defer func() {
+		if allowReason == "" && err == nil {
+			go ps.sendNotification(context.WithoutCancel(ctx), evaluator, pdu, rec)
+		}
+	}()
 	if pdu.Sender == evaluator.Bot.UserID || evaluator.Admins.Has(pdu.Sender) {
 		return "admin", nil, nil
 	}
-	err := evaluator.loadingComplete.Wait(ctx)
+	err = evaluator.loadingComplete.Wait(ctx)
 	if err != nil {
 		return "", nil, err
 	}
@@ -105,7 +113,7 @@ func (ps *PolicyServer) getRecommendation(
 				zerolog.Ctx(ctx).Trace().Bool("spam", rec).Str("protection", name).Msg("Evaluated protection")
 				if rec {
 					return "", &BlockRecommendation{
-						Error:        fmt.Errorf("protections rejected event"),
+						Error:        fmt.Errorf("protection %q rejected event", name),
 						DisplayError: "This message has been rejected as probable spam",
 					}, nil
 				}
@@ -113,6 +121,39 @@ func (ps *PolicyServer) getRecommendation(
 		}
 	}
 	return "no reason to disallow", nil, nil
+}
+
+func (ps *PolicyServer) sendNotification(ctx context.Context, eval *PolicyEvaluator, evt *pdu.PDU, rec *BlockRecommendation) {
+	if rec == nil {
+		return
+	}
+	notifyRoom := eval.protectedRoomsEvent.PolicyServerNotificationRoom
+	if notifyRoom == "" {
+		return
+	}
+	var roomName event.RoomNameEventContent
+	_ = eval.Bot.StateEvent(ctx, evt.RoomID, event.StateRoomName, "", &roomName)
+
+	marshalled, err := json.Marshal(evt, jsontext.WithIndent("  "))
+	if err != nil {
+		marshalled = fmt.Appendf([]byte{}, "\"non JSON object: %v\"", err)
+	}
+	var errMsg string
+	if rec.Error != nil {
+		errMsg = rec.Error.Error()
+	} else {
+		errMsg = rec.DisplayError
+	}
+	eval.Bot.SendNotice(
+		ctx,
+		notifyRoom,
+		"Event %s by %s blocked in %s: %s\n<details><summary>Event JSON</summary>\n\n```json\n%s\n```\n</details>",
+		format.SafeMarkdownCode(evt.Type),
+		format.MarkdownMention(evt.Sender),
+		format.MarkdownMentionRoomID(roomName.Name, evt.RoomID, ps.Federation.ServerName),
+		errMsg,
+		string(marshalled),
+	)
 }
 
 const PolicyServerKeyID id.KeyID = "ed25519:policy_server"

--- a/policyeval/protectedrooms.go
+++ b/policyeval/protectedrooms.go
@@ -265,6 +265,10 @@ func (pe *PolicyEvaluator) handleProtectedRooms(ctx context.Context, evt *event.
 	if len(unsafeProtections) > 0 {
 		output = append(output, fmt.Sprintf("* Warning: the following protections are marked as unsafe and may cause issues: %s", strings.Join(unsafeProtections, ", ")))
 	}
+	psNotifyRoom := content.PolicyServerNotificationRoom
+	if pe.Untrusted && psNotifyRoom != "" && !pe.IsProtectedRoom(psNotifyRoom) {
+		output = append(output, fmt.Sprintf("* Policy server notifications will not be sent to %s as it is not a protected room.", psNotifyRoom))
+	}
 	pe.protectedRoomsLock.Unlock()
 	joinedRooms, err := pe.Bot.JoinedRooms(ctx)
 	if err != nil {

--- a/policyeval/protectedrooms.go
+++ b/policyeval/protectedrooms.go
@@ -266,7 +266,7 @@ func (pe *PolicyEvaluator) handleProtectedRooms(ctx context.Context, evt *event.
 		output = append(output, fmt.Sprintf("* Warning: the following protections are marked as unsafe and may cause issues: %s", strings.Join(unsafeProtections, ", ")))
 	}
 	psNotifyRoom := content.PolicyServerNotificationRoom
-	if pe.Untrusted && psNotifyRoom != "" && !pe.IsProtectedRoom(psNotifyRoom) {
+	if pe.Untrusted && psNotifyRoom != "" && !pe.canReceiveNotifications(psNotifyRoom) {
 		output = append(output, fmt.Sprintf("* Policy server notifications will not be sent to %s as it is not a protected room.", psNotifyRoom))
 	}
 	pe.protectedRoomsLock.Unlock()
@@ -385,4 +385,8 @@ func (pe *PolicyEvaluator) unlockedUpdateUser(userID id.UserID, roomID id.RoomID
 		pe.protectedRoomMembers[userID] = []id.RoomID{}
 	}
 	return false
+}
+
+func (pe *PolicyEvaluator) canReceiveNotifications(roomID id.RoomID) bool {
+	return roomID == pe.ManagementRoom || pe.IsProtectedRoom(roomID)
 }

--- a/policyeval/protectedrooms.go
+++ b/policyeval/protectedrooms.go
@@ -388,5 +388,8 @@ func (pe *PolicyEvaluator) unlockedUpdateUser(userID id.UserID, roomID id.RoomID
 }
 
 func (pe *PolicyEvaluator) canReceiveNotifications(roomID id.RoomID) bool {
+	if !pe.Untrusted {
+		return true
+	}
 	return roomID == pe.ManagementRoom || pe.IsProtectedRoom(roomID)
 }


### PR DESCRIPTION
Closes #66. Disabled by default, but setting a room ID as the value of `policy_server_notification_room` will dispatch policy server notifications to that room. There's no debouncing or anything but given all messy info is collapsed in a \<details\> I don't think that matters.

<img width="1326" height="818" alt="image" src="https://github.com/user-attachments/assets/564d8556-a6f8-4cf9-93e2-fae63f3da7ca" />

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
