### PR TITLE
policyeval: Don't attempt to double-lock protected rooms map

### DIFF
--- a/policyeval/policyserver_check.go
+++ b/policyeval/policyserver_check.go
@@ -135,8 +135,16 @@ func (ps *PolicyServer) sendNotification(ctx context.Context, eval *PolicyEvalua
 		return
 	}
 	notifyRoom := eval.protectedRoomsEvent.PolicyServerNotificationRoom
-	if notifyRoom == "" || (eval.Untrusted && !eval.canReceiveNotifications(notifyRoom)) {
+	if notifyRoom == "" {
 		return
+	}
+	if eval.Untrusted {
+		eval.protectedRoomsLock.RLock()
+		eligible := eval.canReceiveNotificationsUnlocked(notifyRoom)
+		eval.protectedRoomsLock.RUnlock()
+		if !eligible {
+			return
+		}
 	}
 	srcMeta := eval.getProtectedRoomMeta(evt.RoomID)
 

--- a/policyeval/protectedrooms.go
+++ b/policyeval/protectedrooms.go
@@ -266,7 +266,7 @@ func (pe *PolicyEvaluator) handleProtectedRooms(ctx context.Context, evt *event.
 		output = append(output, fmt.Sprintf("* Warning: the following protections are marked as unsafe and may cause issues: %s", strings.Join(unsafeProtections, ", ")))
 	}
 	psNotifyRoom := content.PolicyServerNotificationRoom
-	if pe.Untrusted && psNotifyRoom != "" && !pe.canReceiveNotifications(psNotifyRoom) {
+	if pe.Untrusted && psNotifyRoom != "" && !pe.canReceiveNotificationsUnlocked(psNotifyRoom) {
 		output = append(output, fmt.Sprintf("* Policy server notifications will not be sent to %s as it is not a protected room.", psNotifyRoom))
 	}
 	pe.protectedRoomsLock.Unlock()
@@ -387,9 +387,10 @@ func (pe *PolicyEvaluator) unlockedUpdateUser(userID id.UserID, roomID id.RoomID
 	return false
 }
 
-func (pe *PolicyEvaluator) canReceiveNotifications(roomID id.RoomID) bool {
+func (pe *PolicyEvaluator) canReceiveNotificationsUnlocked(roomID id.RoomID) bool {
 	if !pe.Untrusted {
 		return true
 	}
-	return roomID == pe.ManagementRoom || pe.IsProtectedRoom(roomID)
+	_, protected := pe.protectedRooms[roomID]
+	return roomID == pe.ManagementRoom || protected
 }


### PR DESCRIPTION
#75 inadvertently causes a deadlock in untrusted contexts when a policy server notification room is set to a room other than the management room. This PR avoids the double lock by inlining the call to `IsProtectedRoom` in `canReceiveNotificationsUnlocked`.

### Checklist

* [x] I have read and followed the contributing guidelines at <https://docs.mau.fi/bridges/general/contributing.html>
